### PR TITLE
Add graphql reprsentations of the `Game` model

### DIFF
--- a/server-nest/src/app.controller.spec.ts
+++ b/server-nest/src/app.controller.spec.ts
@@ -29,7 +29,7 @@ describe('AppController', () => {
 
   describe('GET /profile', () => {
     it('should do the thing', () => {
-      const request = req as unknown as Request;
+      const request = (req as unknown) as Request;
       expect(appController.getProfile(request)).toEqual({ foo: 'bar' });
     });
   });

--- a/server-nest/src/errors/index.ts
+++ b/server-nest/src/errors/index.ts
@@ -1,0 +1,1 @@
+export { NoRecordError } from './no-record.exception';

--- a/server-nest/src/errors/no-record.exception.ts
+++ b/server-nest/src/errors/no-record.exception.ts
@@ -5,7 +5,10 @@ export class NoRecordError extends Error {
    * @param id of the record which could not be found.
    * @param recordType used to indicate the type of record.
    */
-  constructor(private readonly id: string, private readonly recordType: string) {
+  constructor(
+    private readonly id: string,
+    private readonly recordType: string
+  ) {
     super();
   }
 

--- a/server-nest/src/errors/no-record.exception.ts
+++ b/server-nest/src/errors/no-record.exception.ts
@@ -1,0 +1,15 @@
+export class NoRecordError extends Error {
+  /**
+   * Indicates an record with the given `id` and `recordType` could not be
+   * located.
+   * @param id of the record which could not be found.
+   * @param recordType used to indicate the type of record.
+   */
+  constructor(private readonly id: string, private readonly recordType: string) {
+    super();
+  }
+
+  get message(): string {
+    return `${this.recordType}(id: "${this.id}") does not exist.`;
+  }
+}

--- a/server-nest/src/game/game.controller.ts
+++ b/server-nest/src/game/game.controller.ts
@@ -13,11 +13,9 @@ import {
 } from '@nestjs/common';
 import { IoValidationPipe } from '../io-validation.pipe';
 import { CreateGameDto, GameMoveDto } from './game.dto';
-import { Game } from './game.model';
+import { Game, GameId } from './game.model';
 import { GameService } from './game.service';
 import { GameView, serializeGame } from './game.view';
-
-type GameId = Game['id'];
 
 @Controller('game')
 export class GameController {
@@ -39,7 +37,7 @@ export class GameController {
 
   @Get(':id')
   @Header('Cache-Control', 'must-revalidate, max-age=60')
-  findOne(@Param('id') id: string): GameView {
+  findOne(@Param('id') id: GameId): GameView {
     const game = this.gameService.findById(id);
     if (typeof game === 'undefined' || game === null) {
       throw new NotFoundException();
@@ -49,7 +47,7 @@ export class GameController {
 
   @Patch(':id')
   @UsePipes(new IoValidationPipe(GameMoveDto))
-  addMove(@Param('id') id: string, @Body() move: GameMoveDto): GameView {
+  addMove(@Param('id') id: GameId, @Body() move: GameMoveDto): GameView {
     const current = this.gameService.findById(id);
     if (typeof current === 'undefined' || current === null) {
       throw new NotFoundException();

--- a/server-nest/src/game/game.dto.ts
+++ b/server-nest/src/game/game.dto.ts
@@ -1,4 +1,6 @@
+import { Field, InputType } from '@nestjs/graphql';
 import * as io from 'io-ts';
+import { GameId } from './game.model';
 
 /**
  * Represent the request body for creating a game instance as a runtime
@@ -21,3 +23,34 @@ export const GameMoveDto = io.type({
 });
 
 export type GameMoveDto = io.TypeOf<typeof GameMoveDto>;
+
+// #region GraphQL
+/**
+ * Represents the input data necessary to create a new `Game`.
+ */
+@InputType()
+export class CreateGameInput {
+  /** How many rows the new `Game` will have. */
+  @Field()
+  rows: number;
+  /** How many columns the new `Game` will have. */
+  @Field()
+  columns: number;
+}
+
+/**
+ * Represents the input data necessary to add a move to an existing `Game`.
+ */
+@InputType()
+export class CreateGameMoveInput {
+  /** Unique identifier for the `Game`. */
+  @Field()
+  id: GameId;
+  /** Column of the cell to open. */
+  @Field()
+  column: number;
+  /** Row of the cell to open. */
+  @Field()
+  row: number;
+}
+// #endregion GraphQL

--- a/server-nest/src/game/game.model.spec.ts
+++ b/server-nest/src/game/game.model.spec.ts
@@ -496,11 +496,11 @@ describe('Game#openCoordinates', () => {
     ]);
   });
 
-  it('throws when row is out of bounds', () => {
-    expect(() => game.openCoordinates(4, 0)).toThrow();
+  it('throws when column is out of bounds', () => {
+    expect(() => game.openCoordinates(4, 0)).toThrowError(/columns/);
   });
 
-  it('throws when column is out of bounds', () => {
-    expect(() => game.openCoordinates(0, 4)).toThrow();
+  it('throws when row is out of bounds', () => {
+    expect(() => game.openCoordinates(0, 4)).toThrowError(/rows/);
   });
 });

--- a/server-nest/src/game/game.model.ts
+++ b/server-nest/src/game/game.model.ts
@@ -24,6 +24,8 @@ interface InitialViews extends GridProps {
   views: CellView[];
 }
 
+export type GameId = string;
+
 export type Props = GridProps | InitialCells | InitialViews;
 
 function generateCells(cellCount: number, mineProbability = 0.25): Cell[] {
@@ -71,7 +73,7 @@ function associateCells(props: InitialCells): void {
 
 export class Game {
   readonly columns: number;
-  readonly id: string;
+  readonly id: GameId;
   readonly moves: CellId[];
   readonly rows: number;
   private _views: CellView[];

--- a/server-nest/src/game/game.model.ts
+++ b/server-nest/src/game/game.model.ts
@@ -167,10 +167,10 @@ export class Game {
 
   private static getIndex(props: GridProps, x: number, y: number): number {
     const { rows, columns } = props;
-    if (x >= rows) {
-      throw new OutOfBoundsException('rows', x);
-    } else if (y >= columns) {
-      throw new OutOfBoundsException('columns', y);
+    if (x >= columns) {
+      throw new OutOfBoundsException('columns', x);
+    } else if (y >= rows) {
+      throw new OutOfBoundsException('rows', y);
     }
     return columns * x + y;
   }

--- a/server-nest/src/game/game.module.ts
+++ b/server-nest/src/game/game.module.ts
@@ -1,11 +1,12 @@
 import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { LoggerMiddleware } from '../logger.middleware';
 import { GameController } from './game.controller';
+import { GamesResolver } from './game.resolver';
 import { GameService } from './game.service';
 
 @Module({
   controllers: [GameController],
-  providers: [GameService],
+  providers: [GamesResolver, GameService],
   exports: [GameService],
 })
 export class GameModule implements NestModule {

--- a/server-nest/src/game/game.resolver.spec.ts
+++ b/server-nest/src/game/game.resolver.spec.ts
@@ -1,0 +1,106 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NoRecordError } from '../errors';
+import { GamesResolver } from './game.resolver';
+import { GameService } from './game.service';
+import { OutOfBoundsException } from './out-of-bounds.exception';
+
+describe(GamesResolver, () => {
+  let resolver: GamesResolver;
+  let service: GameService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [],
+      providers: [GamesResolver, GameService],
+    }).compile();
+
+    resolver = module.get<GamesResolver>(GamesResolver);
+    service = module.get<GameService>(GameService);
+  });
+
+  it('should be defined', () => {
+    expect(resolver).toBeDefined();
+  });
+
+  describe('#createGame', () => {
+    it('creates a game', () => {
+      const result = resolver.createGame({ rows: 3, columns: 3 });
+      expect(result).toBeDefined();
+    });
+
+    it('returns an id', () => {
+      const result = resolver.createGame({ rows: 3, columns: 3 });
+      expect(result.id).toBeDefined();
+    });
+
+    it('returns instance with id, board, status', () => {
+      const result = resolver.createGame({ rows: 3, columns: 3 });
+      expect(Object.keys(result)).toEqual(['board', 'id', 'status']);
+    });
+  });
+
+  describe('#games', () => {
+    it('is an empty list', () => {
+      expect(resolver.games()).toHaveLength(0);
+    });
+
+    it('lists one after create', () => {
+      resolver.createGame({ rows: 3, columns: 3 });
+      expect(resolver.games()).toHaveLength(1);
+    });
+
+    it('lists whole games', () => {
+      const game = resolver.createGame({ rows: 3, columns: 3 });
+      const result = resolver.games();
+      expect(result).toContainEqual(game);
+    });
+  });
+
+  describe('#getGame', () => {
+    it('returns undefined for non-existing id', () => {
+      expect(resolver.getGame('foo')).toBeUndefined();
+    });
+
+    it('serializes a Game', () => {
+      const { id } = resolver.createGame({ rows: 10, columns: 10 });
+      const game = service.findById(id);
+      const result = resolver.getGame(id);
+      expect(result).toHaveProperty('id', id);
+      expect(result.board.flat()).toEqual(game.board);
+      expect(result).toHaveProperty('status');
+    });
+  });
+
+  describe('gameAddMove', () => {
+    const alpha = { column: 0, row: 0 };
+
+    it('throws NoRecordError for non-existing id', () => {
+      expect(() => resolver.gameAddMove({ id: 'foo', ...alpha })).toThrowError(
+        NoRecordError
+      );
+    });
+
+    it('throws OutOfBoundsException for out of bounds row', () => {
+      const { id } = resolver.createGame({ rows: 10, columns: 10 });
+      expect(() =>
+        resolver.gameAddMove({ id, column: 11, row: 0 })
+      ).toThrowError(OutOfBoundsException);
+    });
+
+    it('throws OutOfBoundsException for out of bounds column', () => {
+      const { id } = resolver.createGame({ rows: 10, columns: 10 });
+      expect(() =>
+        resolver.gameAddMove({ id, column: 0, row: 11 })
+      ).toThrowError(OutOfBoundsException);
+    });
+
+    it('updates a Game', () => {
+      const { id } = resolver.createGame({ rows: 10, columns: 10 });
+      const result = resolver.gameAddMove({ id, ...alpha });
+      expect(result).toHaveProperty('id', id);
+      expect(result).toHaveProperty('board');
+      expect(result).toHaveProperty('status');
+    });
+  });
+});
+

--- a/server-nest/src/game/game.resolver.spec.ts
+++ b/server-nest/src/game/game.resolver.spec.ts
@@ -103,4 +103,3 @@ describe(GamesResolver, () => {
     });
   });
 });
-

--- a/server-nest/src/game/game.resolver.ts
+++ b/server-nest/src/game/game.resolver.ts
@@ -10,7 +10,7 @@ export class GamesResolver {
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   @Query((returns) => [GameViewModel])
-  async games(): Promise<GameViewModel[]> {
+  games(): GameViewModel[] {
     return this.gameService.list().map(serializeGame);
   }
 
@@ -29,11 +29,7 @@ export class GamesResolver {
   @Mutation((returns) => GameViewModel)
   createGame(@Args('data') data: CreateGameInput): GameViewModel {
     const model = this.gameService.create(data);
-    if (model) {
-      return serializeGame(model);
-    } else {
-      return undefined;
-    }
+    return serializeGame(model);
   }
 
   @Mutation((returns) => GameViewModel)

--- a/server-nest/src/game/game.resolver.ts
+++ b/server-nest/src/game/game.resolver.ts
@@ -38,13 +38,7 @@ export class GamesResolver {
 
   @Mutation((returns) => GameViewModel)
   gameAddMove(@Args('data') data: CreateGameMoveInput): GameViewModel {
-    const current = this.gameService.findById(data.id);
-    if (typeof current === 'undefined' || current === null) {
-      return undefined;
-    }
-    const next = current.openCoordinates(data.column, data.row);
-    this.gameService.updateById(current.id, next);
+    const next = this.gameService.addMoveById(data.id, data.column, data.row);
     return serializeGame(next);
   }
 }
-

--- a/server-nest/src/game/game.resolver.ts
+++ b/server-nest/src/game/game.resolver.ts
@@ -1,0 +1,50 @@
+import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
+import { GameViewModel, serializeGame } from './game.view';
+import { CreateGameInput, CreateGameMoveInput } from './game.dto';
+import { GameService } from './game.service';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+@Resolver((of) => GameViewModel)
+export class GamesResolver {
+  constructor(private readonly gameService: GameService) {}
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  @Query((returns) => [GameViewModel])
+  async games(): Promise<GameViewModel[]> {
+    return this.gameService.list().map(serializeGame);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  @Query((returns) => GameViewModel, { nullable: true })
+  getGame(@Args('id') id: string): GameViewModel {
+    const model = this.gameService.findById(id);
+    if (model) {
+      return serializeGame(model);
+    } else {
+      return undefined;
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  @Mutation((returns) => GameViewModel)
+  createGame(@Args('data') data: CreateGameInput): GameViewModel {
+    const model = this.gameService.create(data);
+    if (model) {
+      return serializeGame(model);
+    } else {
+      return undefined;
+    }
+  }
+
+  @Mutation((returns) => GameViewModel)
+  gameAddMove(@Args('data') data: CreateGameMoveInput): GameViewModel {
+    const current = this.gameService.findById(data.id);
+    if (typeof current === 'undefined' || current === null) {
+      return undefined;
+    }
+    const next = current.openCoordinates(data.column, data.row);
+    this.gameService.updateById(current.id, next);
+    return serializeGame(next);
+  }
+}
+

--- a/server-nest/src/game/game.service.spec.ts
+++ b/server-nest/src/game/game.service.spec.ts
@@ -106,4 +106,39 @@ describe('GameService', () => {
       expect(service.findById(game.id)).toBe(v2);
     });
   });
+
+  describe('#addMoveById', () => {
+    let game: Game;
+
+    beforeEach(() => {
+      game = service.create({
+        rows: 2,
+        columns: 2,
+      });
+    });
+
+    it('throws for unknown id', () => {
+      expect(() => service.addMoveById(uuid(), 0, 0)).toThrow(NoRecordError);
+    });
+
+    it('returns a new game', () => {
+      const result = service.addMoveById(game.id, 0, 0);
+      expect(result).not.toBe(game);
+    });
+
+    it('returns a game with a new board state', () => {
+      const result = service.addMoveById(game.id, 0, 0);
+      expect(result.board).not.toEqual(game.board);
+    });
+
+    it('returns a game with same id', () => {
+      const result = service.addMoveById(game.id, 0, 0);
+      expect(result).toHaveProperty('id', game.id);
+    });
+
+    it('replaces the old game', () => {
+      const result = service.addMoveById(game.id, 0, 0);
+      expect(service.findById(game.id)).toBe(result);
+    });
+  });
 });

--- a/server-nest/src/game/game.service.spec.ts
+++ b/server-nest/src/game/game.service.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { v4 as uuid } from 'uuid';
+import { NoRecordError } from '../errors';
 import { Game } from './game.model';
 import { GameService } from './game.service';
 
@@ -85,7 +86,7 @@ describe('GameService', () => {
     });
 
     it('throws for unknown id', () => {
-      expect(() => service.updateById(uuid(), null)).toThrow();
+      expect(() => service.updateById(uuid(), null)).toThrow(NoRecordError);
     });
 
     it('throws if ids do not match', () => {

--- a/server-nest/src/game/game.service.ts
+++ b/server-nest/src/game/game.service.ts
@@ -7,6 +7,26 @@ export class GameService {
   private readonly games: Game[] = [];
 
   /**
+   * Find the `Game` associated with `id`, add the move represented by the
+   * column and row to be opened, return the updated `Game`.
+   * @param id of the record to update.
+   * @param column of the `Cell` to open.
+   * @param row of the `Cell` to open.
+   * @returns a `Game` with the move applied.
+   * @throws if `id` does not exist.
+   * @throws if `(column, row)` can not be opened.
+   */
+  addMoveById(id: GameId, column: number, row: number): Game {
+    const current = this.findById(id);
+    if (typeof current === 'undefined' || current === null) {
+      throw new NoRecordError(id, 'Game');
+    }
+    const next = current.openCoordinates(column, row);
+    this.updateById(current.id, next);
+    return next;
+  }
+
+  /**
    * Create a new record and store it.
    * @param data to be stored.
    * @returns the stored Game record.

--- a/server-nest/src/game/game.service.ts
+++ b/server-nest/src/game/game.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { NoRecordError } from '../errors';
 import { Game, GameId, Props } from './game.model';
 
 @Injectable()
@@ -44,7 +45,7 @@ export class GameService {
   updateById(id: GameId, game: Game): Game {
     const gameIndex = this.games.findIndex((game) => game.id === id);
     if (gameIndex === -1) {
-      throw new Error(`No Game with ${id} has been created.`);
+      throw new NoRecordError(id, 'Game');
     } else if (id !== game.id) {
       throw new Error(
         'Can only update a Game with a new version of the same Game.'

--- a/server-nest/src/game/game.service.ts
+++ b/server-nest/src/game/game.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { Game, Props } from './game.model';
+import { Game, GameId, Props } from './game.model';
 
 @Injectable()
 export class GameService {
@@ -29,7 +29,7 @@ export class GameService {
    * @param id of the record to find.
    * @returns the record if one is found or `undefined` if one is not.
    */
-  findById(id: string): Game {
+  findById(id: GameId): Game {
     return this.games.find((game) => game.id === id);
   }
 
@@ -41,7 +41,7 @@ export class GameService {
    * @throws if `id` does not exist.
    * @throws if `id` does not match `game.id`.
    */
-  updateById(id: string, game: Game): Game {
+  updateById(id: GameId, game: Game): Game {
     const gameIndex = this.games.findIndex((game) => game.id === id);
     if (gameIndex === -1) {
       throw new Error(`No Game with ${id} has been created.`);

--- a/server-nest/src/game/game.view.spec.ts
+++ b/server-nest/src/game/game.view.spec.ts
@@ -25,7 +25,9 @@ describe(serializeGame, () => {
     });
 
     it('has a board with appropriate column count', () => {
-      expect(subject.board.every((row) => row.length === game.columns)).toBe(true);
+      expect(subject.board.every((row) => row.length === game.columns)).toBe(
+        true
+      );
     });
 
     it('has a matching board', () => {
@@ -64,11 +66,13 @@ describe(serializeGame, () => {
     });
 
     it('has a board with appropriate row count', () => {
-      expect(subject.board).toHaveLength(game.rows)
+      expect(subject.board).toHaveLength(game.rows);
     });
 
     it('has a board with appropriate column count', () => {
-      expect(subject.board.every((row) => row.length === game.columns)).toBe(true);
+      expect(subject.board.every((row) => row.length === game.columns)).toBe(
+        true
+      );
     });
 
     it('has a matching board', () => {
@@ -109,11 +113,13 @@ describe(serializeGame, () => {
     });
 
     it('has a board with appropriate row count', () => {
-      expect(subject.board).toHaveLength(game.rows)
+      expect(subject.board).toHaveLength(game.rows);
     });
 
     it('has a board with appropriate column count', () => {
-      expect(subject.board.every((row) => row.length === game.columns)).toBe(true);
+      expect(subject.board.every((row) => row.length === game.columns)).toBe(
+        true
+      );
     });
 
     it('has a matching board', () => {

--- a/server-nest/src/game/game.view.ts
+++ b/server-nest/src/game/game.view.ts
@@ -1,11 +1,9 @@
-import { Game, GameId } from './game.model';
-
-type Status = 'WON' | 'LOST' | 'OPEN';
+import { Game, GameId, GameStatus } from './game.model';
 
 export interface GameView {
   board: string[][];
   id: GameId;
-  status: Status;
+  status: GameStatus;
 }
 
 export function serializeGame(game: Game): GameView {

--- a/server-nest/src/game/game.view.ts
+++ b/server-nest/src/game/game.view.ts
@@ -1,3 +1,4 @@
+import { Field, ObjectType, registerEnumType } from '@nestjs/graphql';
 import { Game, GameId, GameStatus } from './game.model';
 
 export interface GameView {
@@ -33,3 +34,25 @@ export function serializeGame(game: Game): GameView {
     status: game.gameStatus,
   };
 }
+
+// #region GraphQL
+registerEnumType(GameStatus, {
+  name: 'GameStatus',
+});
+
+/**
+ * Domain model reprsentation of a game board.
+ */
+@ObjectType()
+export class GameViewModel implements GameView {
+  /** Unique identifier for this cat. */
+  @Field()
+  id: GameId;
+  /** Name for this cat. */
+  @Field(_type => [[String!]!])
+  board: string[][];
+  /** Breed of this cat. */
+  @Field()
+  status: GameStatus;
+}
+// #endregion GraphQL

--- a/server-nest/src/game/game.view.ts
+++ b/server-nest/src/game/game.view.ts
@@ -12,18 +12,9 @@ export function serializeGame(game: Game): GameView {
     (memo, view) => {
       const row = memo.slice(-1)[0];
       if (row.length >= game.columns) {
-        return [
-          ...memo,
-          [view],
-        ];
+        return [...memo, [view]];
       } else {
-        return [
-          ...memo.slice(0, -1),
-          [
-            ...row,
-            view,
-          ]
-        ];
+        return [...memo.slice(0, -1), [...row, view]];
       }
     },
     [[]]
@@ -49,7 +40,7 @@ export class GameViewModel implements GameView {
   @Field()
   id: GameId;
   /** Name for this cat. */
-  @Field(_type => [[String!]!])
+  @Field((_type) => [[String!]!])
   board: string[][];
   /** Breed of this cat. */
   @Field()

--- a/server-nest/src/game/game.view.ts
+++ b/server-nest/src/game/game.view.ts
@@ -1,10 +1,10 @@
-import { Game } from './game.model';
+import { Game, GameId } from './game.model';
 
 type Status = 'WON' | 'LOST' | 'OPEN';
 
 export interface GameView {
   board: string[][];
-  id: Game['id'];
+  id: GameId;
   status: Status;
 }
 

--- a/server-nest/src/io-validation.pipe.spec.ts
+++ b/server-nest/src/io-validation.pipe.spec.ts
@@ -103,7 +103,10 @@ describe('Fail Pipe', () => {
   const FailString = new io.Type<string, string, unknown>(
     'string',
     (_input: unknown): _input is string => false,
-    (input, context) => typeof input === 'string' ? io.success(input) : io.failure(input, context),
+    (input, context) =>
+      typeof input === 'string'
+        ? io.success(input)
+        : io.failure(input, context),
     io.identity
   );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1012,12 +1012,12 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@^7.6.3":
-  version "7.8.4"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.4.tgz#d79f5a2040f7caa24d53e563aad49cbc05581308"
-  integrity sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==
+"@babel/runtime@^7.8.7":
+  version "7.9.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.9.2.tgz#d90df0583a3a252f09aaa619665367bae518db06"
+  integrity sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==
   dependencies:
-    regenerator-runtime "^0.13.2"
+    regenerator-runtime "^0.13.4"
 
 "@babel/template@^7.7.0", "@babel/template@^7.7.4", "@babel/template@^7.8.3", "@babel/template@^7.8.6":
   version "7.8.6"
@@ -7627,9 +7627,9 @@ move-concurrently@^1.0.1:
     run-queue "^1.0.3"
 
 mri@^1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/mri/-/mri-1.1.4.tgz#7cb1dd1b9b40905f1fac053abe25b6720f44744a"
-  integrity sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w==
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/mri/-/mri-1.1.5.tgz#ce21dba2c69f74a9b7cf8a1ec62307e089e223e0"
+  integrity sha512-d2RKzMD4JNyHMbnbWnznPaa8vbdlq/4pNZ3IgdaGrVbBhebBsGUUE/6qorTMYNS6TwuH3ilfOlD2bf4Igh8CKg==
 
 ms@2.0.0:
   version "2.0.0"
@@ -11435,11 +11435,11 @@ yallist@^4.0.0:
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yaml@^1.7.2:
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.7.2.tgz#f26aabf738590ab61efaca502358e48dc9f348b2"
-  integrity sha512-qXROVp90sb83XtAoqE8bP9RwAkTTZbugRUTm5YeFCBfNRPEp2YzTeqWiz7m5OORHzEvrA/qcGS8hp/E+MMROYw==
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.8.3.tgz#2f420fca58b68ce3a332d0ca64be1d191dd3f87a"
+  integrity sha512-X/v7VDnK+sxbQ2Imq4Jt2PRUsRsP7UcpSl3Llg6+NRRqWLIvxkMFYtH1FmvwNGYRKKPa+EPA4qDBlI9WVG1UKw==
   dependencies:
-    "@babel/runtime" "^7.6.3"
+    "@babel/runtime" "^7.8.7"
 
 yargs-parser@^16.1.0:
   version "16.1.0"


### PR DESCRIPTION
- Define the `NoRecordError` in `src/errors`
- Throw `NoRecordError` when a record is expected to exist but did not. In nest controllers this is likely translated to a `NotFoundException`
- Create `GamesResolver` to handle the top level queries and mutations for interacting with `Game` information