### PR TITLE
Change UI pages to use `getServerSideProps` NextJS convention

### DIFF
--- a/server-nest/src/logger.middleware.ts
+++ b/server-nest/src/logger.middleware.ts
@@ -16,6 +16,9 @@ export class LoggerMiddleware implements NestMiddleware {
   use(req: Request, res: Response, next: NextFunction): void {
     const start = Date.now();
     next();
-    Logger.debug(`Completed in ${Date.now() - start}ms`, req.path);
+    Logger.debug(
+      `Completed in ${Date.now() - start}ms`,
+      `${req.method} ${req.path}`
+    );
   }
 }

--- a/ui/src/pages/game/[gameId].tsx
+++ b/ui/src/pages/game/[gameId].tsx
@@ -1,6 +1,6 @@
 import unfetch from 'isomorphic-unfetch';
 import { NextPageContext } from 'next';
-import React, { Fragment, useState } from 'react';
+import React, { Fragment, PropsWithChildren, useState } from 'react';
 import { GameBoard, GameId } from '../../types';
 
 const fetch = unfetch;
@@ -15,8 +15,33 @@ interface BoardProps extends Pick<Props, 'board'> {
   onCell: (col: number, row: number) => void;
 }
 
+interface CellProps {
+  column: number;
+  row: number;
+  onCell: (col: number, row: number) => void;
+}
+
 type Props = GameResponse;
 type State = GameResponse;
+
+function Cell(props: PropsWithChildren<CellProps>): JSX.Element {
+  const { column, row, children, onCell } = props;
+  return (
+    <td
+      key={`${row}:${column}`}
+      valign="middle"
+      align="center"
+      onClick={onCell.bind(null, column, row)}
+      style={{
+        height: '50px',
+        width: '50px',
+        border: '1px solid black',
+      }}
+    >
+      {children}
+    </td>
+  );
+}
 
 function Board(props: BoardProps): JSX.Element {
   const { board, onCell } = props;
@@ -26,19 +51,9 @@ function Board(props: BoardProps): JSX.Element {
         {board.map((row, rowNumber) => (
           <tr key={rowNumber}>
             {row.map((cell, colNumber) => (
-              <td
-                key={`${rowNumber}:${colNumber}`}
-                valign="middle"
-                align="center"
-                onClick={onCell.bind(null, colNumber, rowNumber)}
-                style={{
-                  height: '50px',
-                  width: '50px',
-                  border: '1px solid black',
-                }}
-              >
+              <Cell column={colNumber} row={rowNumber} onCell={onCell}>
                 {cell}
-              </td>
+              </Cell>
             ))}
           </tr>
         ))}

--- a/ui/src/pages/game/[gameId].tsx
+++ b/ui/src/pages/game/[gameId].tsx
@@ -66,9 +66,9 @@ function GameStatus(props: Pick<Props, 'status'>): JSX.Element {
   const { status } = props;
   switch (status) {
     case 'LOST':
-      return (<h2>BOOM 💥</h2>);
+      return <h2>BOOM 💥</h2>;
     case 'WON':
-      return (<h2>You did the thing! 🥳</h2>)
+      return <h2>You did the thing! 🥳</h2>;
     case 'OPEN':
       return <Fragment />;
   }
@@ -89,8 +89,10 @@ function ShowGame(props: Props): JSX.Element {
       body: JSON.stringify({
         x: col,
         y: row,
-      })
-    }).then((response) => response.json()).then((result: GameResponse) => setState(result))
+      }),
+    })
+      .then((response) => response.json())
+      .then((result: GameResponse) => setState(result));
   }
   return (
     <Fragment>

--- a/ui/src/pages/game/[gameId].tsx
+++ b/ui/src/pages/game/[gameId].tsx
@@ -1,5 +1,5 @@
 import unfetch from 'isomorphic-unfetch';
-import { NextPageContext } from 'next';
+import { GetServerSideProps } from 'next';
 import React, { Fragment, PropsWithChildren, useState } from 'react';
 import { GameBoard, GameId } from '../../types';
 
@@ -101,11 +101,19 @@ function ShowGame(props: Props): JSX.Element {
   );
 }
 
-ShowGame.getInitialProps = async (ctx: NextPageContext): Promise<Props> => {
-  const { query } = ctx;
-  const response = await fetch(`http://localhost:3000/game/${query.gameId}`);
-  const result: GameResponse = await response.json();
-  return result;
+export const getServerSideProps: GetServerSideProps<Props> = async (
+  context
+) => {
+  const gameId = context.params?.gameId;
+  const response = await fetch(`http://localhost:3000/game/${gameId}`);
+  const props: GameResponse = response.ok
+    ? await response.json()
+    : {
+        board: [],
+        id: 'server_error',
+        status: 'LOST',
+      };
+  return { props };
 };
 
 export default ShowGame;

--- a/ui/src/pages/index.tsx
+++ b/ui/src/pages/index.tsx
@@ -43,7 +43,7 @@ Home.getInitialProps = async ({ req }): Promise<Props> => {
   const userAgent = req ? req.headers['user-agent'] || '' : navigator.userAgent;
   return {
     gameIds: result || [],
-    userAgent
+    userAgent,
   };
 };
 

--- a/ui/src/pages/index.tsx
+++ b/ui/src/pages/index.tsx
@@ -1,5 +1,5 @@
 import unfetch from 'isomorphic-unfetch';
-import { NextPage } from 'next';
+import { NextPage, GetServerSideProps } from 'next';
 import Link from 'next/link';
 import React from 'react';
 import { GameListResponse, GameId } from '../types';
@@ -8,7 +8,6 @@ const fetch = unfetch;
 
 interface Props {
   gameIds: GameListResponse;
-  userAgent: string;
 }
 
 interface GameLinkProps {
@@ -24,7 +23,7 @@ function GameLink(props: GameLinkProps): JSX.Element {
   );
 }
 
-const Home: NextPage<Props> = ({ gameIds }: Props) => (
+const HomePage: NextPage<Props> = ({ gameIds }) => (
   <React.Fragment>
     <h1>Let&apos;s Play Minesweeper</h1>
     <ol>
@@ -37,14 +36,13 @@ const Home: NextPage<Props> = ({ gameIds }: Props) => (
   </React.Fragment>
 );
 
-Home.getInitialProps = async ({ req }): Promise<Props> => {
+export const getServerSideProps: GetServerSideProps<Props> = async () => {
   const response = await fetch('http://localhost:3000/game');
-  const result: GameListResponse = await response.json();
-  const userAgent = req ? req.headers['user-agent'] || '' : navigator.userAgent;
-  return {
-    gameIds: result || [],
-    userAgent,
+  const gameIds: GameListResponse = await response.json();
+  const props: Props = {
+    gameIds: response.ok ? gameIds : [],
   };
+  return { props };
 };
 
-export default Home;
+export default HomePage;


### PR DESCRIPTION
The `getServerSideProps` executes only during SSR. The `GamePage` and `HomePage` components now handle responses from the API other than `OK`. The `HomePage` shows an empty list while the `GamePage` renders a 404.