### PR TITLE
Create deployable containers for API and UI

### DIFF
--- a/.github/workflows/build-image-api.yml
+++ b/.github/workflows/build-image-api.yml
@@ -1,0 +1,15 @@
+name: Build API Container Images
+on:
+  pull_request:
+    paths:
+      - 'server-nest/**'
+jobs:
+  build_api_container:
+    name: api
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME: api
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build the Docker image
+        run: docker build . --file Api.Dockerfile --tag ${{ github.repository }}/${IMAGE_NAME}:${{ github.sha }}

--- a/.github/workflows/build-image-ui.yml
+++ b/.github/workflows/build-image-ui.yml
@@ -1,0 +1,15 @@
+name: Build UI Container Image
+on:
+  pull_request:
+    paths:
+      - 'ui/**'
+jobs:
+  build_ui_container:
+    name: ui
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME: ui
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build the Docker image
+        run: docker build . --file Ui.Dockerfile --tag ${{ github.repository }}/${IMAGE_NAME}:${{ github.sha }}

--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -1,0 +1,72 @@
+name: Build and Publish Containers
+on:
+  push:
+    # Publish `master` as Docker `latest` image.
+    branches:
+      - master
+    paths:
+      - 'server-nest/**'
+      - 'ui/**'
+    # Publish `v1.2.3` tags as releases.
+    tags:
+      - v*
+jobs:
+  # Publish image to GitHub Packages.
+  # See also https://docs.docker.com/docker-hub/builds/
+  publish_api_container:
+    runs-on: ubuntu-latest
+    # Only publish if triggered by a push event
+    if: github.event_name == 'push'
+    env:
+      IMAGE_NAME: api
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build image
+        run: docker build . --file Api.Dockerfile --tag image
+      - name: Log into registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+      - name: Push image
+        run: |
+          IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/${IMAGE_NAME}
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "master" ] && VERSION=latest
+          # Print the id and version used
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+          # Tag the perviously built image
+          docker tag image $IMAGE_ID:$VERSION
+          # Push the tagged image to package management
+          docker push $IMAGE_ID:$VERSION
+  publish_ui_container:
+    name: ui
+    runs-on: ubuntu-latest
+    # Only publish if triggered by a push event
+    if: github.event_name == 'push'
+    env:
+      IMAGE_NAME: ui
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build image
+        run: docker build . --file Ui.Dockerfile --tag image
+      - name: Log into registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+      - name: Push image
+        run: |
+          IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/${IMAGE_NAME}
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "master" ] && VERSION=latest
+          # Print the id and version used
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+          # Tag the perviously built image
+          docker tag image $IMAGE_ID:$VERSION
+          # Push the tagged image to package management
+          docker push $IMAGE_ID:$VERSION

--- a/Api.Dockerfile
+++ b/Api.Dockerfile
@@ -1,0 +1,39 @@
+# Stage to buid the model interfaces
+FROM node:12-alpine as builder
+# Work from this directory to build model
+WORKDIR /usr/src/
+# Move to latest OS packages and add openssl and certificates
+RUN apk update && apk upgrade && apk add --no-cache openssl ca-certificates
+# Copy files indicating dependencies
+COPY package.json yarn.lock tsconfig.base.json ./
+# Copy packages
+COPY server-nest ./server-nest/
+# Install dependencies, don't let yarn change versions
+RUN yarn install --frozen-lockfile
+# Create the built project
+RUN yarn workspace @mines/nest build
+
+# Stage to buid the model interfaces
+FROM node:12-alpine as app
+# Work from this directory to build model
+WORKDIR /usr/src/
+# Move to latest OS packages and add openssl and certificates
+RUN apk update && apk upgrade && apk add --no-cache openssl ca-certificates
+# Set NODE_ENV for the server
+ENV NODE_ENV production
+# Tell server to use port 3000
+ENV PORT 3000
+# Expose port 3000
+EXPOSE 3000
+# Copy dependency information from `builder`, but only the workspace specific
+# `package.json`
+COPY --from=builder /usr/src/server-nest/package.json /usr/src/yarn.lock ./
+# Copy the compiled result from `builder`
+COPY --from=builder /usr/src/server-nest/dist ./src
+# Install production dependencies, don't let yarn change versions
+RUN yarn install --production --frozen-lockfile
+# Create a healthcheck for the container
+HEALTHCHECK --timeout=500ms --interval=2s --retries=3 --start-period=3s \
+  CMD printf "GET /ping\r\n\r\n" | nc 127.0.0.1 3000 | grep -e '^PONG$'
+# Start the app
+ENTRYPOINT ["/bin/sh", "-c", "node ./src/main.js"]

--- a/README.md
+++ b/README.md
@@ -68,6 +68,15 @@ To run the locally built Docker image:
 
     docker run --name=mines-ui --detach --publish=8080:80 mines-ui:<version>
 
+### Environment Variables
+
+The [`Makefile`](./Makefile) will pull parameters defined in AWS SSM under the
+`/mines/dev/ui` path and place them into `ui/.env`. The `ui/.env.sample` file
+includes the names of environment variables the `@mines/ui` package expects.
+
+- _API_BASE_URL_ is base URL including scheme (and port if needed) of the API
+  server.
+
 ## docker-compose
 
 The [`docker-compose.yml`](./docker-compose.yml) defines a

--- a/Ui.Dockerfile
+++ b/Ui.Dockerfile
@@ -29,10 +29,18 @@ EXPOSE 3000
 ENV NODE_ENV production
 # Copy dependency information from `builder`, but only the workspace specific
 # `package.json`
-COPY --from=builder /usr/src/ui/package.json /usr/src/yarn.lock ./
+# Copy the healthcheck script
+COPY --from=builder \
+  /usr/src/ui/package.json \
+  /usr/src/ui/healthcheck.js \
+  /usr/src/yarn.lock \
+  ./
 # Copy the compiled result from `builder`
 COPY --from=builder /usr/src/ui/src/.next ./src/.next
 # Install production dependencies, don't let yarn change versions
 RUN yarn install --production --frozen-lockfile
+# Create a healthcheck for the container
+HEALTHCHECK --timeout=1s --interval=2s --retries=3 --start-period=3s \
+  CMD node healthcheck.js
 # Start the app
 ENTRYPOINT ["/bin/sh", "-c", "yarn run start"]

--- a/Ui.Dockerfile
+++ b/Ui.Dockerfile
@@ -43,4 +43,4 @@ RUN yarn install --production --frozen-lockfile
 HEALTHCHECK --timeout=1s --interval=2s --retries=3 --start-period=3s \
   CMD node healthcheck.js
 # Start the app
-ENTRYPOINT ["/bin/sh", "-c", "yarn run start"]
+ENTRYPOINT ["/bin/sh", "-c", "$(npm bin)/next start src"]

--- a/Ui.Dockerfile
+++ b/Ui.Dockerfile
@@ -1,5 +1,7 @@
 # Stage to buid the model interfaces
 FROM node:12-alpine as builder
+# The API_BASE_URL to inject into the NextJS build
+ARG api_base_url
 # Work from this directory to build model
 WORKDIR /usr/src/
 # Move to latest OS packages and add openssl and certificates
@@ -10,6 +12,8 @@ COPY package.json yarn.lock ./
 COPY ui ./ui/
 # Install dependencies, don't let yarn change versions
 RUN yarn install --frozen-lockfile
+# Inject the API_BASE_URL into the NextJS build
+ENV API_BASE_URL $api_base_url
 # Create the built project
 RUN yarn workspace @mines/ui build
 

--- a/Ui.Dockerfile
+++ b/Ui.Dockerfile
@@ -23,15 +23,16 @@ FROM node:12-alpine as app
 WORKDIR /usr/src/
 # Move to latest OS packages and add openssl and certificates
 RUN apk update && apk upgrade && apk add --no-cache openssl ca-certificates
-# Expose port 80
+# Expose port 3000, the NextJS default
 EXPOSE 3000
 # Set NODE_ENV for the server
 ENV NODE_ENV production
-# Copy dependency information from builder
+# Copy dependency information from `builder`, but only the workspace specific
+# `package.json`
 COPY --from=builder /usr/src/ui/package.json /usr/src/yarn.lock ./
-# Copy the built static files to the html folder
+# Copy the compiled result from `builder`
 COPY --from=builder /usr/src/ui/src/.next ./src/.next
-# Install dependencies, don't let yarn change versions
+# Install production dependencies, don't let yarn change versions
 RUN yarn install --production --frozen-lockfile
 # Start the app
 ENTRYPOINT ["/bin/sh", "-c", "yarn run start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,29 @@
 version: '3'
 services:
+  api:
+    container_name: api
+    build:
+      dockerfile: Api.Dockerfile
+      context: .
+    ports:
+      - '3000:3000'
+    env_file: ./server-nest/.env
+    environment:
+      - PORT=3000
+
+  ui:
+    container_name: ui
+    build:
+      dockerfile: Ui.Dockerfile
+      context: .
+      args:
+        - api_base_url=http://api:3000
+    ports:
+      - '4000:3000'
+    env_file: ./ui/.env
+    depends_on:
+      - api
+
   eventstore.db:
     image: eventstore/eventstore
     environment:

--- a/server-nest/src/app.controller.spec.ts
+++ b/server-nest/src/app.controller.spec.ts
@@ -27,6 +27,12 @@ describe('AppController', () => {
     });
   });
 
+  describe('GET /ping', () => {
+    it('responds with PONG', () => {
+      expect(appController.getPing()).toBe('PONG');
+    });
+  });
+
   describe('GET /profile', () => {
     it('should do the thing', () => {
       const request = (req as unknown) as Request;

--- a/server-nest/src/app.controller.ts
+++ b/server-nest/src/app.controller.ts
@@ -13,6 +13,11 @@ export class AppController {
     return this.appService.getHello();
   }
 
+  @Get('/ping')
+  getPing(): string {
+    return 'PONG';
+  }
+
   @UseGuards(JwtAuthGuard)
   @Get('/profile')
   getProfile(@Req() req: Request): JwtPayload {

--- a/ui/.env.sample
+++ b/ui/.env.sample
@@ -1,1 +1,2 @@
-FOO=
+# Base URL including scheme (and port if needed) of the API server
+API_BASE_URL="http://localhost:3000"

--- a/ui/healthcheck.js
+++ b/ui/healthcheck.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+const http = require('http');
+
+// ************************************************************************** *
+// This runs in the HEALTHCHECK of the Ui.Dockerfile. It is executed directly *
+// without the use of any transpilers, so it must be "stock" JS and rely only *
+// on `node` APIs.                                                            *
+// ************************************************************************** *
+
+const options = {
+  host: 'localhost',
+  method: 'HEAD',
+  port: '3000',
+  timeout: 500,
+};
+
+const req = http.request(options, (res) => {
+  console.log(`STATUS: ${res.statusCode}`);
+  if (res.statusCode == 200) {
+    process.exit(0);
+  } else {
+    process.exit(1);
+  }
+});
+
+req.on('error', (err) => {
+  console.warn(`ERROR: ${err.name}(${err.message})`);
+  process.exit(1);
+});
+
+req.end();

--- a/ui/next.config.js
+++ b/ui/next.config.js
@@ -1,0 +1,7 @@
+module.exports = (phase, { defaultConfig }) => {
+  return {
+    env: {
+      API_BASE_URL: process.env.API_BASE_URL || 'http://localhost:3000',
+    },
+  };
+};

--- a/ui/src/pages/game/[gameId].tsx
+++ b/ui/src/pages/game/[gameId].tsx
@@ -89,7 +89,7 @@ function Game(props: GameProps): JSX.Element {
     if (state.status !== 'OPEN') {
       return;
     }
-    return fetch(`http://localhost:3000/game/${id}`, {
+    return fetch(`${process.env.API_BASE_URL}/game/${id}`, {
       method: 'PATCH',
       headers: {
         'Content-Type': 'application/json',
@@ -123,7 +123,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async (
   context
 ) => {
   const gameId = context.params?.gameId;
-  const response = await fetch(`http://localhost:3000/game/${gameId}`);
+  const response = await fetch(`${process.env.API_BASE_URL}/game/${gameId}`);
   const props: GameResponse = response.ok
     ? await response.json()
     : {

--- a/ui/src/pages/index.tsx
+++ b/ui/src/pages/index.tsx
@@ -37,7 +37,7 @@ const HomePage: NextPage<Props> = ({ gameIds }) => (
 );
 
 export const getServerSideProps: GetServerSideProps<Props> = async () => {
-  const response = await fetch('http://localhost:3000/game');
+  const response = await fetch(`${process.env.API_BASE_URL}/game`);
   const gameIds: GameListResponse = await response.json();
   const props: Props = {
     gameIds: response.ok ? gameIds : [],


### PR DESCRIPTION
The UI project uses an `API_BASE_URL` environment variable at container build time to determine where the REST API for fetching data is located. The `Ui.Dockerfile` expects an `api_base_url` argument to be provided. Within `docker-compose.yml` the `api_base_url` is defined to point at the api container. The container definitions for Api and Ui include `HEALTHCHECK` which test their servers are running and accepting connections.

GitHub Actions are defined to build the containers for pull requests (to ensure they continue to build). Tags and pushes to `master` publish the built containers to the GitHub package registry.