### PR TITLE
Fix `getNeighborChain` to get all neighbors of empty cells

### DIFF
--- a/server-nest/src/game/cell.model.spec.ts
+++ b/server-nest/src/game/cell.model.spec.ts
@@ -105,6 +105,55 @@ describe(Cell, () => {
   });
 });
 
+describe(`
+| 0 | 0 | 1 | M |
+`, () => {
+  const cell_0_0 = new Cell({ isMine: false });
+  const cell_1_0 = new Cell({ isMine: false });
+  const cell_2_0 = new Cell({ isMine: false });
+  const cell_3_0 = new Cell({ isMine: true });
+
+  beforeEach(() => {
+    cell_0_0.add('right', cell_1_0);
+    cell_1_0.add('right', cell_2_0);
+    cell_2_0.add('right', cell_3_0);
+  });
+
+  describe('cell_0_0.neighborsChain', () => {
+    it('has a neighbor chain of two', () => {
+      expect(cell_0_0.neighborsChain).toHaveLength(2);
+    });
+
+    it('includes cell_1_0', () => {
+      expect(cell_0_0.neighborsChain).toContain(cell_1_0);
+    });
+
+    it('includes cell_2_0', () => {
+      expect(cell_0_0.neighborsChain).toContain(cell_2_0);
+    });
+  });
+
+  describe('cell_1_0.neighborsChain', () => {
+    it('has a neighbor chain of two', () => {
+      expect(cell_1_0.neighborsChain).toHaveLength(2);
+    });
+
+    it('includes cell_0_0', () => {
+      expect(cell_1_0.neighborsChain).toContain(cell_0_0);
+    });
+
+    it('includes cell_2_0', () => {
+      expect(cell_1_0.neighborsChain).toContain(cell_2_0);
+    });
+  });
+
+  describe('cell_2_0.neighborsChain', () => {
+    it('has a neighbor chain of zero', () => {
+      expect(cell_2_0.neighborsChain).toHaveLength(0);
+    });
+  });
+});
+
 // Generate a 2x2 game
 describe(`
 | ' ' | 'M' |
@@ -305,7 +354,7 @@ describe('Cell.neighborsChain', () => {
 
     describe('cell_0_0', () => {
       it('has two chained neighbors', () => {
-        expect(cell_0_0.neighborsChain).toHaveLength(2);
+        expect(cell_0_0.neighborsChain).toHaveLength(5);
       });
     });
 
@@ -323,7 +372,7 @@ describe('Cell.neighborsChain', () => {
 
     describe('cell_1_0', () => {
       it('has no chained neighbors', () => {
-        expect(cell_1_0.neighborsChain).toHaveLength(2);
+        expect(cell_1_0.neighborsChain).toHaveLength(5);
       });
     });
 
@@ -341,7 +390,7 @@ describe('Cell.neighborsChain', () => {
 
     describe('cell_2_0', () => {
       it('has no chained neighbors', () => {
-        expect(cell_2_0.neighborsChain).toHaveLength(2);
+        expect(cell_2_0.neighborsChain).toHaveLength(5);
       });
     });
 

--- a/server-nest/src/game/cell.model.ts
+++ b/server-nest/src/game/cell.model.ts
@@ -113,9 +113,10 @@ export class Cell {
 
   private getNeighborChain(ignore: CellId[]): Cell[] {
     const neighborIds = this.neighbors.map((cell) => cell.id);
-    const chainedNeighbors = this.neighbors.filter(
-      (cell) => !ignore.includes(cell.id) && cell.isEmpty
-    );
+    const ignoredIds = (cell: Cell) => !ignore.includes(cell.id);
+    const chainedNeighbors = this.isEmpty
+      ? this.neighbors.filter(ignoredIds)
+      : [];
     const chainsFromNeighbors = chainedNeighbors
       .map((cell) => cell.getNeighborChain([...ignore, ...neighborIds]))
       .flat();

--- a/server-nest/src/game/game.model.spec.ts
+++ b/server-nest/src/game/game.model.spec.ts
@@ -379,9 +379,9 @@ describe('Game#open', () => {
     const subject = game.open(cells[cells.length - 1].id);
     // prettier-ignore
     expect(subject.board).toEqual([
-      ' ', ' ', ' ', '0',
-      ' ', ' ', ' ', '0',
-      ' ', ' ', ' ', '0',
+      ' ', ' ', '2', '0',
+      ' ', ' ', '2', '0',
+      '2', '2', '1', '0',
       '0', '0', '0', '0',
     ]);
   });
@@ -466,9 +466,9 @@ describe('Game#openCoordinates', () => {
     const subject = game.openCoordinates(3, 3);
     // prettier-ignore
     expect(subject.board).toEqual([
-      ' ', ' ', ' ', '0',
-      ' ', ' ', ' ', '0',
-      ' ', ' ', ' ', '0',
+      ' ', ' ', '2', '0',
+      ' ', ' ', '2', '0',
+      '2', '2', '1', '0',
       '0', '0', '0', '0',
     ]);
   });

--- a/ui/src/pages/game/[gameId].tsx
+++ b/ui/src/pages/game/[gameId].tsx
@@ -60,7 +60,12 @@ function Board(props: BoardProps): JSX.Element {
         {board.map((row, rowNumber) => (
           <tr key={rowNumber}>
             {row.map((cell, colNumber) => (
-              <Cell column={colNumber} row={rowNumber} onCell={onCell}>
+              <Cell
+                key={`(${colNumber},${rowNumber})`}
+                column={colNumber}
+                row={rowNumber}
+                onCell={onCell}
+              >
                 {cell}
               </Cell>
             ))}


### PR DESCRIPTION
If a `Cell` is empty then all its neighbors should get opened, if a cell is not empty none of its neighbors should be opened. If any neighbor `Cell` is empty then chain the behavior to the neighbor `Cell` as well.