### PR TITLE
Add a `GameMove` and `GameMoveType`

### DIFF
--- a/server-nest/src/game/cell.model.ts
+++ b/server-nest/src/game/cell.model.ts
@@ -48,6 +48,10 @@ const DEFAULT_CELL_STATE: Required<CellState> = {
   isOpen: false,
 };
 
+export function pickCellId(cell: Cell): CellId {
+  return cell.id;
+}
+
 export class Cell {
   readonly id: CellId;
   readonly initialState: Required<CellState>;

--- a/server-nest/src/game/game-move.model.ts
+++ b/server-nest/src/game/game-move.model.ts
@@ -1,0 +1,21 @@
+import { CellId } from './cell.model';
+
+/**
+ * Represent the type of game "moves" or "actions" which can be taken on a
+ * cell.
+ */
+export enum GameMoveType {
+  FLAG = 'FLAG',
+  OPEN = 'OPEN',
+}
+
+/**
+ * Define the structure of data required to apply a "move" or "action" to a
+ * game.
+ */
+export interface GameMove {
+  /** Identifier of the `Cell` to which the action applies. */
+  cellId: CellId;
+  /** Type of action taken on the given `Cell`. */
+  type: GameMoveType;
+}

--- a/server-nest/src/game/game.controller.spec.ts
+++ b/server-nest/src/game/game.controller.spec.ts
@@ -4,7 +4,9 @@ import {
 } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { GameController } from './game.controller';
+import { GameMoveDto } from './game.dto';
 import { GameService } from './game.service';
+import { GameMoveType } from './game-move.model';
 
 describe(GameController, () => {
   let controller: GameController;
@@ -74,7 +76,8 @@ describe(GameController, () => {
   });
 
   describe('PATCH /:id', () => {
-    const alpha = { x: 0, y: 0 };
+    const alpha: GameMoveDto = { column: 0, type: GameMoveType.OPEN, row: 0 };
+    const type = GameMoveType.OPEN;
 
     it('throws NotFoundException for non-existing id', () => {
       expect(() => controller.addMove('foo', alpha)).toThrowError(
@@ -84,16 +87,16 @@ describe(GameController, () => {
 
     it('throws UnprocessableEntityException for out of bounds row', () => {
       const { id } = controller.create({ rows: 10, columns: 10 });
-      expect(() => controller.addMove(id, { x: 11, y: 0 })).toThrowError(
-        UnprocessableEntityException
-      );
+      expect(() =>
+        controller.addMove(id, { column: 11, type, row: 0 })
+      ).toThrowError(UnprocessableEntityException);
     });
 
     it('throws UnprocessableEntityException for out of bounds column', () => {
       const { id } = controller.create({ rows: 10, columns: 10 });
-      expect(() => controller.addMove(id, { x: 0, y: 11 })).toThrowError(
-        UnprocessableEntityException
-      );
+      expect(() =>
+        controller.addMove(id, { column: 0, type, row: 11 })
+      ).toThrowError(UnprocessableEntityException);
     });
 
     it('updates a Game', () => {

--- a/server-nest/src/game/game.controller.ts
+++ b/server-nest/src/game/game.controller.ts
@@ -50,7 +50,7 @@ export class GameController {
   @UsePipes(new IoValidationPipe(GameMoveDto))
   addMove(@Param('id') id: GameId, @Body() move: GameMoveDto): GameView {
     try {
-      const next = this.gameService.addMoveById(id, move.x, move.y);
+      const next = this.gameService.addMoveById(id, move);
       return serializeGame(next);
     } catch (error) {
       if (error instanceof NoRecordError) {

--- a/server-nest/src/game/game.dto.ts
+++ b/server-nest/src/game/game.dto.ts
@@ -1,6 +1,7 @@
-import { Field, InputType } from '@nestjs/graphql';
+import { Field, InputType, registerEnumType } from '@nestjs/graphql';
 import * as io from 'io-ts';
 import { GameId } from './game.model';
+import { GameMoveType } from './game-move.model';
 
 /**
  * Represent the request body for creating a game instance as a runtime
@@ -18,13 +19,18 @@ export type CreateGameDto = io.TypeOf<typeof CreateGameDto>;
  * type.
  */
 export const GameMoveDto = io.type({
-  x: io.number,
-  y: io.number,
+  column: io.number,
+  row: io.number,
+  type: io.keyof(GameMoveType),
 });
 
 export type GameMoveDto = io.TypeOf<typeof GameMoveDto>;
 
 // #region GraphQL
+registerEnumType(GameMoveType, {
+  name: 'GameMoveType',
+});
+
 /**
  * Represents the input data necessary to create a new `Game`.
  */
@@ -46,11 +52,14 @@ export class CreateGameMoveInput {
   /** Unique identifier for the `Game`. */
   @Field()
   id: GameId;
-  /** Column of the cell to open. */
+  /** Column of the cell to act upon. */
   @Field()
   column: number;
-  /** Row of the cell to open. */
+  /** Row of the cell to act upon. */
   @Field()
   row: number;
+  /** The type of move to create for the game with given id. */
+  @Field()
+  type: GameMoveType;
 }
 // #endregion GraphQL

--- a/server-nest/src/game/game.model.spec.ts
+++ b/server-nest/src/game/game.model.spec.ts
@@ -44,6 +44,15 @@ describe(Game, () => {
         ' ', ' ',
       ]);
     });
+
+    it('shows flag when 0,0 is flagged', () => {
+      const updatedGame = game.flagCoordinates(0, 0);
+      // prettier-ignore
+      expect(updatedGame.board).toEqual([
+        'F', ' ',
+        ' ', ' ',
+      ]);
+    });
   });
 
   describe(`
@@ -314,6 +323,95 @@ describe('new Game', () => {
       expect(game.cells[2].getNeighbor('topRight')).toBe(game.cells[1]);
       expect(game.cells[2].getNeighbor('right')).toBe(game.cells[3]);
     });
+  });
+});
+
+describe('Game#flagCoordinates', () => {
+  let cells: Cell[];
+  let game: Game;
+
+  beforeAll(() => {
+    // | 3 | M | 2 | 0 |
+    // | M | M | 2 | 0 |
+    // | 2 | 2 | 1 | 0 |
+    // | 0 | 0 | 0 | 0 |
+    cells = [
+      // Row 1
+      new Cell({ isMine: false }),
+      new Cell({ isMine: true }),
+      new Cell({ isMine: false }),
+      new Cell({ isMine: false }),
+      // Row 2
+      new Cell({ isMine: true }),
+      new Cell({ isMine: true }),
+      new Cell({ isMine: false }),
+      new Cell({ isMine: false }),
+      // Row 3
+      new Cell({ isMine: false }),
+      new Cell({ isMine: false }),
+      new Cell({ isMine: false }),
+      new Cell({ isMine: false }),
+      // Row 4
+      new Cell({ isMine: false }),
+      new Cell({ isMine: false }),
+      new Cell({ isMine: false }),
+      new Cell({ isMine: false }),
+    ];
+  });
+
+  beforeEach(() => {
+    game = new Game({
+      rows: 4,
+      columns: 4,
+      cells,
+    });
+  });
+
+  it('retains the id', () => {
+    const subject = game.flagCoordinates(0, 0);
+    expect(subject.id).toEqual(game.id);
+  });
+
+  it('flags only one cell', () => {
+    const subject = game.flagCoordinates(0, 0);
+    // prettier-ignore
+    expect(subject.board).toEqual([
+      'F', ' ', ' ', ' ',
+      ' ', ' ', ' ', ' ',
+      ' ', ' ', ' ', ' ',
+      ' ', ' ', ' ', ' ',
+    ]);
+  });
+
+  it('does not lose game when flagging mine', () => {
+    const subject = game.flagCoordinates(1, 0);
+    // prettier-ignore
+    expect(subject.board).toEqual([
+      ' ', 'F', ' ', ' ',
+      ' ', ' ', ' ', ' ',
+      ' ', ' ', ' ', ' ',
+      ' ', ' ', ' ', ' ',
+    ]);
+    expect(subject.gameStatus).toBe(GameStatus.OPEN);
+  });
+
+  it('flags cell at (2, 2)', () => {
+    const subject = game.flagCoordinates(2, 2);
+    // prettier-ignore
+    expect(subject.board).toEqual([
+      ' ', ' ', ' ', ' ',
+      ' ', ' ', ' ', ' ',
+      ' ', ' ', 'F', ' ',
+      ' ', ' ', ' ', ' ',
+    ]);
+  });
+
+  it('throws when column is out of bounds', () => {
+    expect(() => game.flagCoordinates(4, 0)).toThrowError(/columns/);
+  });
+
+  it('throws when row is out of bounds', () => {
+    expect(() => game.flagCoordinates(0, 4)).toThrowError(/rows/);
   });
 });
 

--- a/server-nest/src/game/game.model.ts
+++ b/server-nest/src/game/game.model.ts
@@ -13,11 +13,11 @@ interface GridProps {
   columns: number;
   rows: number;
   id?: string;
-  moves?: CellId[];
 }
 
 interface InitialCells extends GridProps {
   cells: Cell[];
+  moves?: CellId[];
 }
 
 interface InitialViews extends GridProps {
@@ -81,15 +81,18 @@ export class Game {
   private viewCache: Record<CellId, CellView>;
 
   constructor(props: Props) {
-    const { rows, columns, moves = [] } = props;
+    const { rows, columns } = props;
     // Assign views based on the contents of props
     if ('views' in props) {
       // InitialViews
+      this.moves = [];
       this.views = props.views;
     } else if ('cells' in props) {
       // InitialCells
       const cells = props.cells;
+      const moves = props.moves || [];
       associateCells({ rows, columns, cells });
+      this.moves = moves;
       this.views = cells.map(
         (cell) =>
           new CellView(cell, {
@@ -101,6 +104,7 @@ export class Game {
       const cellCount = rows * columns;
       const cells = generateCells(cellCount);
       associateCells({ rows, columns, cells });
+      this.moves = [];
       this.views = cells.map((cell) => new CellView(cell));
     }
     if ('id' in props) {
@@ -109,7 +113,6 @@ export class Game {
       this.id = uuid();
     }
     this.columns = columns;
-    this.moves = moves;
     this.rows = rows;
   }
 

--- a/server-nest/src/game/game.model.ts
+++ b/server-nest/src/game/game.model.ts
@@ -207,6 +207,21 @@ export class Game {
     });
   }
 
+  /**
+   * Create a lookup table of `CellId -> CellView` from the given list of `CellView`.
+   * @param views used to create a lookup table.
+   * @returns a lookup table of `CellId -> CellView`.
+   */
+  private static computeViewCache(views: CellView[]): Record<CellId, CellView> {
+    return views.reduce(
+      (cache, view) => ({
+        ...cache,
+        [view.id]: view,
+      }),
+      {}
+    );
+  }
+
   private static getIndex(
     props: GridProps,
     column: number,
@@ -239,12 +254,6 @@ export class Game {
 
   private set views(views: CellView[]) {
     this._views = views;
-    this.viewCache = views.reduce(
-      (cache, view) => ({
-        ...cache,
-        [view.id]: view,
-      }),
-      {}
-    );
+    this.viewCache = Game.computeViewCache(this.views);
   }
 }

--- a/server-nest/src/game/game.model.ts
+++ b/server-nest/src/game/game.model.ts
@@ -125,6 +125,13 @@ export class Game {
     this.rows = rows;
   }
 
+  flagCoordinates(column: number, row: number): Game {
+    const gridProps = { rows: this.rows, columns: this.columns };
+    const cellIndex = Game.getIndex(gridProps, column, row);
+    const cellId = this.cells[cellIndex].id;
+    return this.copyWithFlaggedCell(cellId);
+  }
+
   open(cellId: CellId): Game {
     const moves = [...this.moves, { type: GameMoveType.OPEN, cellId }];
     const openedCell = this.viewCache[cellId];
@@ -139,6 +146,7 @@ export class Game {
     const views = this.views.map(
       (view) =>
         new CellView(view.cell, {
+          isFlagged: view.isFlagged,
           isOpen: openedCellIds.includes(view.id) || view.isOpen,
         })
     );
@@ -175,6 +183,28 @@ export class Game {
     } else {
       return GameStatus.OPEN;
     }
+  }
+
+  private copyWithFlaggedCell(cellId: CellId): Game {
+    const moves = [...this.moves, { type: GameMoveType.FLAG, cellId }];
+    const flaggedCell = this.viewCache[cellId];
+    if (typeof flaggedCell === 'undefined') {
+      throw new Error(`Cell with id ${cellId} does not exist`);
+    }
+    const views = this.views.map(
+      (view) =>
+        new CellView(view.cell, {
+          isFlagged: view.isFlagged || cellId === view.id,
+          isOpen: view.isOpen,
+        })
+    );
+    return new Game({
+      rows: this.rows,
+      columns: this.columns,
+      id: this.id,
+      views,
+      moves,
+    });
   }
 
   private static getIndex(

--- a/server-nest/src/game/game.model.ts
+++ b/server-nest/src/game/game.model.ts
@@ -13,12 +13,12 @@ export enum GameStatus {
 interface GridProps {
   columns: number;
   rows: number;
+  moves?: GameMove[];
   id?: string;
 }
 
 interface InitialCells extends GridProps {
   cells: Cell[];
-  moves?: GameMove[];
 }
 
 interface InitialViews extends GridProps {
@@ -80,25 +80,22 @@ export class Game {
   private views: CellView[];
 
   constructor(props: Props) {
-    const { rows, columns } = props;
+    const { rows, columns, moves = [] } = props;
     // Assign views based on the contents of props
     if ('views' in props) {
       // InitialViews
-      this.moves = [];
+      // NOTE: If `moves.length > 0` maybe validate the `views` match?
       this.views = props.views;
     } else if ('cells' in props) {
       // InitialCells
       const cells = props.cells;
-      const moves = props.moves || [];
       associateCells({ rows, columns, cells });
-      this.moves = moves;
       this.views = Game.computeViews(moves, cells);
     } else {
       // GridProps
       const cellCount = rows * columns;
       const cells = generateCells(cellCount);
       associateCells({ rows, columns, cells });
-      this.moves = [];
       this.views = Game.computeViews([], cells);
     }
     if ('id' in props) {
@@ -107,6 +104,7 @@ export class Game {
       this.id = uuid();
     }
     this.columns = columns;
+    this.moves = moves;
     this.rows = rows;
   }
 
@@ -158,8 +156,8 @@ export class Game {
       rows: this.rows,
       columns: this.columns,
       id: this.id,
-      views,
       moves,
+      views,
     });
   }
 

--- a/server-nest/src/game/game.model.ts
+++ b/server-nest/src/game/game.model.ts
@@ -77,9 +77,7 @@ export class Game {
   readonly id: GameId;
   readonly moves: GameMove[];
   readonly rows: number;
-  private _views: CellView[];
-  // `viewCache` is upated when `views` is assigned via the `views` setter.
-  private viewCache: Record<CellId, CellView>;
+  private views: CellView[];
 
   constructor(props: Props) {
     const { rows, columns } = props;
@@ -262,12 +260,7 @@ export class Game {
     );
   }
 
-  private get views(): CellView[] {
-    return this._views;
-  }
-
-  private set views(views: CellView[]) {
-    this._views = views;
-    this.viewCache = Game.computeViewCache(this.views);
+  private get viewCache(): Record<CellId, CellView> {
+    return Game.computeViewCache(this.views);
   }
 }

--- a/server-nest/src/game/game.resolver.spec.ts
+++ b/server-nest/src/game/game.resolver.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { NoRecordError } from '../errors';
 import { GamesResolver } from './game.resolver';
 import { GameService } from './game.service';
+import { GameMoveType } from './game-move.model';
 import { OutOfBoundsException } from './out-of-bounds.exception';
 
 describe(GamesResolver, () => {
@@ -72,7 +73,8 @@ describe(GamesResolver, () => {
   });
 
   describe('gameAddMove', () => {
-    const alpha = { column: 0, row: 0 };
+    const alpha = { column: 0, type: GameMoveType.OPEN, row: 0 };
+    const type = GameMoveType.OPEN;
 
     it('throws NoRecordError for non-existing id', () => {
       expect(() => resolver.gameAddMove({ id: 'foo', ...alpha })).toThrowError(
@@ -83,14 +85,14 @@ describe(GamesResolver, () => {
     it('throws OutOfBoundsException for out of bounds row', () => {
       const { id } = resolver.createGame({ rows: 10, columns: 10 });
       expect(() =>
-        resolver.gameAddMove({ id, column: 11, row: 0 })
+        resolver.gameAddMove({ id, column: 11, row: 0, type })
       ).toThrowError(OutOfBoundsException);
     });
 
     it('throws OutOfBoundsException for out of bounds column', () => {
       const { id } = resolver.createGame({ rows: 10, columns: 10 });
       expect(() =>
-        resolver.gameAddMove({ id, column: 0, row: 11 })
+        resolver.gameAddMove({ id, column: 0, row: 11, type })
       ).toThrowError(OutOfBoundsException);
     });
 

--- a/server-nest/src/game/game.resolver.ts
+++ b/server-nest/src/game/game.resolver.ts
@@ -34,7 +34,7 @@ export class GamesResolver {
 
   @Mutation((returns) => GameViewModel)
   gameAddMove(@Args('data') data: CreateGameMoveInput): GameViewModel {
-    const next = this.gameService.addMoveById(data.id, data.column, data.row);
+    const next = this.gameService.addMoveById(data.id, data);
     return serializeGame(next);
   }
 }

--- a/server-nest/src/game/game.service.spec.ts
+++ b/server-nest/src/game/game.service.spec.ts
@@ -1,8 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { v4 as uuid } from 'uuid';
 import { NoRecordError } from '../errors';
+import { GameMoveDto } from './game.dto';
 import { Game } from './game.model';
 import { GameService } from './game.service';
+import { GameMoveType } from './game-move.model';
 
 describe('GameService', () => {
   let service: GameService;
@@ -108,6 +110,7 @@ describe('GameService', () => {
   });
 
   describe('#addMoveById', () => {
+    const moveTypes = [GameMoveType.FLAG, GameMoveType.OPEN];
     let game: Game;
 
     beforeEach(() => {
@@ -117,28 +120,41 @@ describe('GameService', () => {
       });
     });
 
-    it('throws for unknown id', () => {
-      expect(() => service.addMoveById(uuid(), 0, 0)).toThrow(NoRecordError);
-    });
+    for (let i = 0; i < moveTypes.length; i++) {
+      const moveType = moveTypes[i];
+      describe(moveType, () => {
+        let move: GameMoveDto;
 
-    it('returns a new game', () => {
-      const result = service.addMoveById(game.id, 0, 0);
-      expect(result).not.toBe(game);
-    });
+        beforeEach(() => {
+          move = { column: 0, type: moveType, row: 0 };
+        });
 
-    it('returns a game with a new board state', () => {
-      const result = service.addMoveById(game.id, 0, 0);
-      expect(result.board).not.toEqual(game.board);
-    });
+        it('throws for unknown id', () => {
+          expect(() => service.addMoveById(uuid(), move)).toThrow(
+            NoRecordError
+          );
+        });
 
-    it('returns a game with same id', () => {
-      const result = service.addMoveById(game.id, 0, 0);
-      expect(result).toHaveProperty('id', game.id);
-    });
+        it('returns a new game', () => {
+          const result = service.addMoveById(game.id, move);
+          expect(result).not.toBe(game);
+        });
 
-    it('replaces the old game', () => {
-      const result = service.addMoveById(game.id, 0, 0);
-      expect(service.findById(game.id)).toBe(result);
-    });
+        it('returns a game with a new board state', () => {
+          const result = service.addMoveById(game.id, move);
+          expect(result.board).not.toEqual(game.board);
+        });
+
+        it('returns a game with same id', () => {
+          const result = service.addMoveById(game.id, move);
+          expect(result).toHaveProperty('id', game.id);
+        });
+
+        it('replaces the old game', () => {
+          const result = service.addMoveById(game.id, move);
+          expect(service.findById(game.id)).toBe(result);
+        });
+      });
+    }
   });
 });

--- a/server-nest/src/game/game.service.ts
+++ b/server-nest/src/game/game.service.ts
@@ -1,6 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import { NoRecordError } from '../errors';
+import { GameMoveDto } from './game.dto';
 import { Game, GameId, Props } from './game.model';
+import { GameMoveType } from './game-move.model';
 
 @Injectable()
 export class GameService {
@@ -16,12 +18,21 @@ export class GameService {
    * @throws if `id` does not exist.
    * @throws if `(column, row)` can not be opened.
    */
-  addMoveById(id: GameId, column: number, row: number): Game {
+  addMoveById(id: GameId, move: GameMoveDto): Game {
     const current = this.findById(id);
     if (typeof current === 'undefined' || current === null) {
       throw new NoRecordError(id, 'Game');
     }
-    const next = current.openCoordinates(column, row);
+    const { column, row } = move;
+    let next: Game;
+    switch (move.type) {
+      case GameMoveType.FLAG:
+        next = current.flagCoordinates(column, row);
+        break;
+      case GameMoveType.OPEN:
+        next = current.openCoordinates(column, row);
+        break;
+    }
     this.updateById(current.id, next);
     return next;
   }

--- a/server-nest/src/game/game.view.spec.ts
+++ b/server-nest/src/game/game.view.spec.ts
@@ -1,5 +1,6 @@
 import { Cell } from './cell.model';
 import { Game } from './game.model';
+import { GameMoveType } from './game-move.model';
 import { GameView, serializeGame } from './game.view';
 
 describe(serializeGame, () => {
@@ -99,7 +100,7 @@ describe(serializeGame, () => {
         rows: 2,
         columns: 2,
         cells,
-        moves: [cells[0].id],
+        moves: [{ type: GameMoveType.OPEN, cellId: cells[0].id }],
       });
       subject = serializeGame(game);
     });

--- a/server-nest/src/game/game.view.ts
+++ b/server-nest/src/game/game.view.ts
@@ -36,13 +36,13 @@ registerEnumType(GameStatus, {
  */
 @ObjectType()
 export class GameViewModel implements GameView {
-  /** Unique identifier for this cat. */
+  /** Unique identifier for this game. */
   @Field()
   id: GameId;
-  /** Name for this cat. */
+  /** Board state for this game. */
   @Field((_type) => [[String!]!])
   board: string[][];
-  /** Breed of this cat. */
+  /** Current status for this game. */
   @Field()
   status: GameStatus;
 }

--- a/ui/src/pages/game/[gameId].tsx
+++ b/ui/src/pages/game/[gameId].tsx
@@ -116,15 +116,16 @@ function Game(props: GameProps): JSX.Element {
     if (state.status !== 'OPEN') {
       return;
     }
-    const { column: col, row } = interactProps;
+    const { column: col, row, flag: isFlag } = interactProps;
     return fetch(`${process.env.API_BASE_URL}/game/${id}`, {
       method: 'PATCH',
       headers: {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        x: col,
-        y: row,
+        column: col,
+        row: row,
+        type: isFlag ? 'FLAG' : 'OPEN',
       }),
     })
       .then((response) => response.json())


### PR DESCRIPTION
Change the `moves` list on the `Game` model to be a list of `GameMove` instances. The combination of `GameMove[]` and `Cell[]` lead to a specific `Game` state. As such given a list of `GameMove` and `Cell` the `CellView[]` can be computed and so can the `GameStatus` of the `Game` instance.

Change the `GameController` and `GamesResolver` to expect a `type` property in the `PATCH /game/:id` and `gameAddMove` mutations respectively. These will mean the relatively easy ability to add new `GameMoveType` later as all the "view" logic exists in the `Game` model. The API interactions only append the recorded move.