### PR TITLE
Add tests for error cases

### DIFF
--- a/migrations/versions/R__Game_Cells_View.sql
+++ b/migrations/versions/R__Game_Cells_View.sql
@@ -12,7 +12,7 @@ CREATE OR REPLACE VIEW game_cells AS (
                 'id', game_cell.cell_id
             ) AS cell
          FROM game_cell
-         ORDER BY game_cell.game_sequence_id
+         ORDER BY game_cell.game_id, game_cell.game_sequence_id
     ) as game_data
     GROUP BY game_id
 );

--- a/server-nest/src/game/cell.model.spec.ts
+++ b/server-nest/src/game/cell.model.spec.ts
@@ -35,6 +35,34 @@ describe(Cell, () => {
     });
   });
 
+  describe('#toJSON', () => {
+    let model: Cell;
+
+    beforeEach(() => {
+      model = new Cell();
+    });
+
+    it('has only specific keys', () => {
+      const subject = model.toJSON();
+      expect(Object.keys(subject)).toEqual(['id', 'isMine']);
+    });
+
+    it('has the same id', () => {
+      const subject = model.toJSON();
+      expect(model.id).toEqual(subject.id);
+    });
+
+    it('has the same mine value', () => {
+      const subject = model.toJSON();
+      expect(model.isMine).toEqual(subject.isMine);
+    });
+
+    it('stringifies to json record', () => {
+      const subject = model.toJSON();
+      expect(JSON.stringify(subject)).toEqual(JSON.stringify(model));
+    });
+  });
+
   describe('not a mine', () => {
     const isMine = false;
 

--- a/server-nest/src/game/game.controller.spec.ts
+++ b/server-nest/src/game/game.controller.spec.ts
@@ -116,5 +116,16 @@ describe(GameController, () => {
       expect(result).toHaveProperty('board');
       expect(result).toHaveProperty('status');
     });
+
+    it('updates a Game by flagging', async () => {
+      const { id } = await controller.create({ rows: 10, columns: 10 });
+      const result = await controller.addMove(id, {
+        ...alpha,
+        type: GameMoveType.FLAG,
+      });
+      expect(result).toHaveProperty('id', id);
+      expect(result).toHaveProperty('board');
+      expect(result).toHaveProperty('status');
+    });
   });
 });

--- a/server-nest/src/game/game.service.spec.ts
+++ b/server-nest/src/game/game.service.spec.ts
@@ -187,11 +187,25 @@ describe('GameService', () => {
         // SELECT FROM game
         .mockResolvedValueOnce({
           rowCount: 1,
-          rows: [genGameRecord({ id: game.id })],
+          rows: [
+            genGameRecord({
+              id: game.id,
+              moves: [
+                { cell_id: game.cells[0].id, move_type: GameMoveType.OPEN },
+              ],
+            }),
+          ],
         });
       const result = await service.list();
       expect(result).toHaveLength(1);
       expect(result.map((g) => g.id)).toContain(game.id);
+    });
+
+    it('rethrows an error', async () => {
+      mockClient.query
+        // SELECT FROM game
+        .mockRejectedValue(new Error('Fake Error'));
+      expect(() => service.list()).rejects.toThrow('Fake Error');
     });
   });
 

--- a/server-nest/src/game/game.service.spec.ts
+++ b/server-nest/src/game/game.service.spec.ts
@@ -232,6 +232,27 @@ describe('GameService', () => {
       const result = await service.findById(game.id);
       expect(result).toEqual(game);
     });
+
+    it('throws when single record not found', async () => {
+      const game = new Game({ columns: 2, rows: 2 });
+      mockClient.query
+        // SELECT FROM game
+        .mockResolvedValueOnce({
+          rowCount: 2,
+          rows: [makeGameRecord(game), makeGameRecord(game)],
+        });
+      expect(() => service.findById(game.id)).rejects.toThrow(
+        /^Found multiple records with game_id/
+      );
+    });
+
+    it('throws if the query throws', async () => {
+      const game = new Game({ columns: 2, rows: 2 });
+      mockClient.query
+        // SELECT FROM game
+        .mockRejectedValueOnce(new Error('Fake Error'));
+      expect(() => service.findById(game.id)).rejects.toThrow('Fake Error');
+    });
   });
 
   describe('#addMoveById', () => {

--- a/server-nest/src/game/game.service.ts
+++ b/server-nest/src/game/game.service.ts
@@ -116,7 +116,7 @@ export class GameService implements BaseGameService {
         );
       } else if (gameIds.rows[0].id !== game.id) {
         throw new Error(
-          `Game created with a different. Actual: ${gameIds.rows[0].id} Expected: ${game.id}`
+          `Game created with a different id. Actual: ${gameIds.rows[0].id} Expected: ${game.id}`
         );
       }
       const cellInsertRaw = `

--- a/server-nest/src/game/game.service.ts
+++ b/server-nest/src/game/game.service.ts
@@ -237,9 +237,7 @@ export class GameService implements BaseGameService {
       );
       return games.pop();
     } catch (error) {
-      // Whatever error happened means we didn't find a record.
-      // TODO: Log the error
-      return undefined;
+      throw error;
     } finally {
       client.release();
     }


### PR DESCRIPTION
Define tests to exercise error throwing and error handling logic, especially in `GameService` methods. Fix some logical errors and error messages highlighted by writing test cases. In particular, `GameService#findById` will re-throw errors encountered while querying rather than swallowing them and returning `undefined`.
