### PR TITLE
History API fallback and improved testing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,12 @@
 .github
 .vscode
+.watchman
+dist
+migrations
 node_modules
-server-express
+server-nest/coverage
+server-nest/dist
+server-nest/node_modules
 ui/build
 ui/dist
 ui/node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ coverage/
 
 # editors
 .vscode/settings.json
+.idea/
 
 # production
 build/

--- a/server-nest/src/auth/auth.service.spec.ts
+++ b/server-nest/src/auth/auth.service.spec.ts
@@ -47,10 +47,13 @@ describe(AuthService, () => {
     });
 
     describe(`#validateUser(${username}, ${badPassword})`, () => {
-      it('throws an error for incorrect password', () => {
-        expect(
-          subject.validateUser(username, badPassword)
-        ).rejects.toBeInstanceOf(UnauthorizedException);
+      it('throws an error for incorrect password', async () => {
+        try {
+          await subject.validateUser(username, badPassword);
+          fail('Expected an error to be thrown');
+        } catch (error) {
+          expect(error).toBeInstanceOf(UnauthorizedException);
+        }
       });
     });
   });

--- a/server-nest/src/errors/game-complete.exception.ts
+++ b/server-nest/src/errors/game-complete.exception.ts
@@ -1,0 +1,16 @@
+import { Game } from '../game/game.model';
+
+export class GameCompleteError extends Error {
+  /**
+   * Indicates the given Game has already been completed, no new moves will be
+   * accepted.
+   * @param game of the record which could not be found.
+   */
+  constructor(private readonly game: Game) {
+    super();
+  }
+
+  get message(): string {
+    return `Game(id: "${this.game.id}") is already ${this.game.gameStatus}.`;
+  }
+}

--- a/server-nest/src/errors/index.ts
+++ b/server-nest/src/errors/index.ts
@@ -1,1 +1,2 @@
+export { GameCompleteError } from './game-complete.exception';
 export { NoRecordError } from './no-record.exception';

--- a/server-nest/src/game/game.controller.spec.ts
+++ b/server-nest/src/game/game.controller.spec.ts
@@ -69,10 +69,13 @@ describe(GameController, () => {
   });
 
   describe('GET /:id', () => {
-    it('throws NotFoundException for non-existing id', () => {
-      expect(() => controller.findOne('foo')).rejects.toThrowError(
-        NotFoundException
-      );
+    it('throws NotFoundException for non-existing id', async () => {
+      try {
+        await controller.findOne('foo');
+        fail('Expected an error to be thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(NotFoundException);
+      }
     });
 
     it('serializes a Game', async () => {
@@ -89,24 +92,33 @@ describe(GameController, () => {
     const alpha: GameMoveDto = { column: 0, type: GameMoveType.OPEN, row: 0 };
     const type = GameMoveType.OPEN;
 
-    it('throws NotFoundException for non-existing id', () => {
-      expect(() => controller.addMove('foo', alpha)).rejects.toThrowError(
-        NotFoundException
-      );
+    it('throws NotFoundException for non-existing id', async () => {
+      try {
+        await controller.addMove('foo', alpha);
+        fail('Expected an error to be thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(NotFoundException);
+      }
     });
 
     it('throws UnprocessableEntityException for out of bounds row', async () => {
       const { id } = await controller.create({ rows: 10, columns: 10 });
-      expect(() =>
-        controller.addMove(id, { column: 11, type, row: 0 })
-      ).rejects.toThrowError(UnprocessableEntityException);
+      try {
+        await controller.addMove(id, { column: 11, type, row: 0 });
+        fail('Expected an error to be thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(UnprocessableEntityException);
+      }
     });
 
     it('throws UnprocessableEntityException for out of bounds column', async () => {
       const { id } = await controller.create({ rows: 10, columns: 10 });
-      expect(() =>
-        controller.addMove(id, { column: 0, type, row: 11 })
-      ).rejects.toThrowError(UnprocessableEntityException);
+      try {
+        await controller.addMove(id, { column: 0, type, row: 11 });
+        fail('Expected an error to be thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(UnprocessableEntityException);
+      }
     });
 
     it('updates a Game', async () => {

--- a/server-nest/src/game/game.controller.ts
+++ b/server-nest/src/game/game.controller.ts
@@ -1,5 +1,6 @@
 import {
   Body,
+  ConflictException,
   Controller,
   Get,
   Header,
@@ -11,7 +12,7 @@ import {
   UnprocessableEntityException,
   UsePipes,
 } from '@nestjs/common';
-import { NoRecordError } from '../errors';
+import { GameCompleteError, NoRecordError } from '../errors';
 import { IoValidationPipe } from '../io-validation.pipe';
 import { CreateGameDto, GameMoveDto } from './game.dto';
 import { Game, GameId } from './game.model';
@@ -59,6 +60,11 @@ export class GameController {
     } catch (error) {
       if (error instanceof NoRecordError) {
         throw new NotFoundException();
+      } else if (error instanceof GameCompleteError) {
+        throw new ConflictException({
+          statusCode: 409,
+          message: error.message,
+        });
       } else {
         throw new UnprocessableEntityException(
           'Coordinates out of range.',

--- a/server-nest/src/game/game.model.ts
+++ b/server-nest/src/game/game.model.ts
@@ -248,16 +248,23 @@ export class Game {
       .map((move) => move.cellId);
   }
 
-  private get isLost(): boolean {
+  private static isLost(views: CellView[]): boolean {
     // if any open cells are a mine; game is lost
-    return this.views.some((view) => view.isOpen && view.isMine);
+    return views.some((view) => view.isOpen && view.isMine);
+  }
+
+  private static isWon(views: CellView[]): boolean {
+    // if all cells except mines are open; game is won
+    return views.every((view) => (view.isOpen ? !view.isMine : view.isMine));
+  }
+
+  private get isLost(): boolean {
+    return Game.isLost(this.views);
   }
 
   private get isWon(): boolean {
     // if all cells except mines are open; game is won
-    return this.views.every((view) =>
-      view.isOpen ? !view.isMine : view.isMine
-    );
+    return Game.isWon(this.views);
   }
 
   private get viewCache(): Record<CellId, CellView> {

--- a/ui-rs/crates/mines_mogwai/src/api.rs
+++ b/ui-rs/crates/mines_mogwai/src/api.rs
@@ -29,7 +29,7 @@ pub mod model {
         OPEN,
     }
 
-    #[derive(Clone, Copy, Debug, Deserialize)]
+    #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
     pub enum GameStatus {
         OPEN,
         WON,

--- a/ui-rs/crates/mines_mogwai/src/components/game.rs
+++ b/ui-rs/crates/mines_mogwai/src/components/game.rs
@@ -56,9 +56,6 @@ fn board_cell<'a>(
     });
     builder! {
         <td
-            valign="middle"
-            align="center"
-            style="height: 50px; width: 50px; border: 1px solid black;"
             on:click=tx.contra_map(move |event: &Event| CellInteract::new((col, row), event))
         >
             // Cells initialize to empty but may update if revealed or clicked

--- a/ui-rs/crates/mines_mogwai/src/lib.rs
+++ b/ui-rs/crates/mines_mogwai/src/lib.rs
@@ -28,9 +28,9 @@ pub fn run_app() -> Result<(), JsValue> {
     console_log::init_with_level(log::Level::Trace).expect("could not init console_log");
 
     if cfg!(debug_assertions) {
-        log::trace!("Hello from debug mogwai-multipage");
+        log::trace!("Hello from debug @mines/uirs");
     } else {
-        log::trace!("Hello from release mogwai-multipage");
+        log::trace!("Hello from release @mines/uirs");
     }
 
     let initial_route = Route::from(utils::window().location().pathname().unwrap_throw());

--- a/ui-rs/crates/mines_mogwai/src/routes.rs
+++ b/ui-rs/crates/mines_mogwai/src/routes.rs
@@ -27,9 +27,9 @@ pub fn game(game_id: api::GameId) -> ViewBuilder<HtmlElement> {
     tx_game.wire_map(&rx_game_board, |game_state| CellUpdate::All {
         cells: game_state.board.clone(),
     });
-    let tx =
+    let tx_api =
         tx_game.contra_filter_map(|r: &Result<api::GameState, api::FetchError>| r.clone().ok());
-    tx.send_async(api::get_game(game_id));
+    tx_api.send_async(api::get_game(game_id));
     // Set up to receive later board states
     tx_cells.spawn_recv().respond(move |interaction| {
         let input = api::GameMoveInput {
@@ -41,7 +41,7 @@ pub fn game(game_id: api::GameId) -> ViewBuilder<HtmlElement> {
                 false => api::GameMoveType::OPEN,
             },
         };
-        tx.send_async(api::patch_game(input));
+        tx_api.send_async(api::patch_game(input));
     });
     // Patch the initial board state into the game board slot
     let rx_patch_game = rx_game_board.branch_filter_map(move |update| match update {

--- a/ui-rs/crates/mines_mogwai/src/routes.rs
+++ b/ui-rs/crates/mines_mogwai/src/routes.rs
@@ -1,86 +1,12 @@
+mod game;
 mod game_list;
 mod index;
 
-use crate::api;
 use mogwai::prelude::*;
 
+pub use game::game;
 pub use game_list::GameList;
 pub use index::home;
-
-#[allow(unused_braces)]
-pub fn game(game_id: api::GameId) -> ViewBuilder<HtmlElement> {
-    use crate::components::game::{self, CellInteract, CellUpdate};
-    // Create a transmitter to send button clicks into.
-    let tx_game: Transmitter<api::GameState> = Transmitter::new();
-    let tx_cells: Transmitter<CellInteract> = Transmitter::new();
-    let rx_cell_updates = Receiver::new();
-    let rx_game_board = Receiver::new();
-    let rx_game_status = Receiver::new();
-    tx_cells.wire_map(&rx_cell_updates, |interaction| CellUpdate::Single {
-        column: interaction.column,
-        row: interaction.row,
-        value: match interaction.flag {
-            true => "F".into(),
-            false => "*".into(),
-        },
-    });
-    // Fetch the initial board state
-    tx_game.wire_map(&rx_game_board, |game_state| CellUpdate::All {
-        cells: game_state.board.clone(),
-    });
-    tx_game.wire_filter_map(&rx_game_status, |game_state| match game_state.status {
-        api::GameStatus::WON => Some(Patch::Replace {
-            index: 0,
-            value: builder! { <h2>"You did the thing! 🥳"</h2> },
-        }),
-        api::GameStatus::LOST => Some(Patch::Replace {
-            index: 0,
-            value: builder! { <h2>"BOOM 💥"</h2> },
-        }),
-        api::GameStatus::OPEN => None,
-    });
-    let tx_api =
-        tx_game.contra_filter_map(|r: &Result<api::GameState, api::FetchError>| r.clone().ok());
-    tx_api.send_async(api::get_game(game_id));
-    // Set up to receive later board states
-    tx_cells.spawn_recv().respond(move |interaction| {
-        let input = api::GameMoveInput {
-            game_id,
-            column: interaction.column,
-            row: interaction.row,
-            move_type: match interaction.flag {
-                true => api::GameMoveType::FLAG,
-                false => api::GameMoveType::OPEN,
-            },
-        };
-        tx_api.send_async(api::patch_game(input));
-    });
-    // Patch the initial board state into the game board slot
-    let rx_patch_game = rx_game_board.branch_filter_map(move |update| match update {
-        CellUpdate::All { cells } => Some(Patch::Replace {
-            index: 0,
-            value: game::board(cells.clone(), &tx_cells, &rx_cell_updates),
-        }),
-        _ => None,
-    });
-    builder! {
-        <main class="container">
-            <div class="overlay">
-                "This site is only supported in portrait mode."
-            </div>
-            <div class="game-board" data-game-id=&game_id.to_hyphenated().to_string()>
-                <slot name="game-board" patch:children=rx_patch_game>
-                    <table>
-                        <tbody />
-                    </table>
-                </slot>
-            </div>
-            <slot name="game-status" patch:children=rx_game_status>
-                <span></span>
-            </slot>
-        </main>
-    }
-}
 
 pub fn not_found() -> ViewBuilder<HtmlElement> {
     builder! {

--- a/ui-rs/crates/mines_mogwai/src/routes/game.rs
+++ b/ui-rs/crates/mines_mogwai/src/routes/game.rs
@@ -1,0 +1,86 @@
+use crate::{api, components};
+use mogwai::prelude::*;
+
+#[allow(unused_braces)]
+pub fn game(game_id: api::GameId) -> ViewBuilder<HtmlElement> {
+    use components::game::CellInteract;
+    // Create a transmitter to send button clicks into.
+    let tx_game: Transmitter<api::GameState> = Transmitter::new();
+    let tx_cells: Transmitter<CellInteract> = Transmitter::new();
+    // Create the upstream `Transmitter` for `tx_game` (i.e. messages sent to `tx_api` will be
+    // passed to `tx_game` if the response is success.
+    let tx_api =
+        tx_game.contra_filter_map(|r: &Result<api::GameState, api::FetchError>| r.clone().ok());
+    tx_api.send_async(api::get_game(game_id));
+    // Set up to receive board interactions which will trigger future board states through api
+    // responses received in `tx_api`.
+    tx_cells.spawn_recv().respond(move |interaction| {
+        let input = api::GameMoveInput {
+            game_id,
+            column: interaction.column,
+            row: interaction.row,
+            move_type: match interaction.flag {
+                true => api::GameMoveType::FLAG,
+                false => api::GameMoveType::OPEN,
+            },
+        };
+        tx_api.send_async(api::patch_game(input));
+    });
+    builder! {
+        <main class="container">
+            <div class="overlay">
+                "This site is only supported in portrait mode."
+            </div>
+            <div class="game-board" data-game-id=&game_id.to_hyphenated().to_string()>
+                {game_board(&tx_game, tx_cells)}
+            </div>
+            {game_status(&tx_game)}
+        </main>
+    }
+}
+
+fn game_board(
+    tx_game: &Transmitter<api::GameState>,
+    tx_cells: Transmitter<components::game::CellInteract>,
+) -> ViewBuilder<HtmlElement> {
+    use components::game::CellUpdate;
+    let rx_game_board = Receiver::new();
+    tx_game.wire_map(&rx_game_board, |game_state| CellUpdate::All {
+        cells: game_state.board.clone(),
+    });
+    // Patch the initial board state into the game board slot
+    let rx_patch_game = rx_game_board.branch_filter_map(move |update| match update {
+        CellUpdate::All { cells } => Some(Patch::Replace {
+            index: 0,
+            value: components::game::board(cells.clone(), &tx_cells),
+        }),
+        _ => None,
+    });
+    builder! {
+        <slot name="game-board" patch:children=rx_patch_game>
+            <table>
+                <tbody />
+            </table>
+        </slot>
+    }
+}
+
+fn game_status(tx_game: &Transmitter<api::GameState>) -> ViewBuilder<HtmlElement> {
+    let rx_game_status = Receiver::new();
+    tx_game.wire_filter_map(&rx_game_status, |game_state| match game_state.status {
+        api::GameStatus::WON => Some(Patch::Replace {
+            index: 0,
+            value: builder! { <h2>"You did the thing! 🥳"</h2> },
+        }),
+        api::GameStatus::LOST => Some(Patch::Replace {
+            index: 0,
+            value: builder! { <h2>"BOOM 💥"</h2> },
+        }),
+        api::GameStatus::OPEN => None,
+    });
+    builder! {
+        <slot name="game-status" patch:children=rx_game_status>
+            <span></span>
+        </slot>
+    }
+}

--- a/ui-rs/package.json
+++ b/ui-rs/package.json
@@ -9,7 +9,7 @@
   },
   "homepage": "https://github.com/bryanjswift/the-mines-challenge#readme",
   "scripts": {
-    "start": "webpack serve",
+    "start": "webpack serve --history-api-fallback",
     "build": "webpack",
     "build:watch": "webpack --watch"
   },

--- a/ui-rs/src/index.css
+++ b/ui-rs/src/index.css
@@ -1,3 +1,11 @@
+slot[name='game-board'] td {
+  border: 1px solid black;
+  width: 50px;
+  height: 50px;
+  valign: middle;
+  text-align: center;
+}
+
 ol li.active {
   color: red;
 }

--- a/ui-rs/webpack.config.ts
+++ b/ui-rs/webpack.config.ts
@@ -38,6 +38,8 @@ const config: webpack.Configuration = {
     ...(dev ? [new webpack.HotModuleReplacementPlugin()] : []),
     new MiniCssExtractPlugin({ filename: '[name].[chunkhash].css' }),
     new HtmlWebpackPlugin({
+      inject: 'body',
+      publicPath: '/',
       template: 'src/index.ejs',
     }),
     new webpack.DefinePlugin({


### PR DESCRIPTION
Change the configuration for starting up the webpack-dev-server to use the history API fallback to allow the user interface code to handle routing in the browser, meaning each path should serve the same assets to the browser. While testing the game after the history changes I found paths to get into unexpected game states and started to 1) make it not possible to get into those states 2) add tests to verify those states are not possible to reach. This further led to writing tests for the mogwai based user interface code.