### PR TITLE
Update node and rust dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist/
 server-nest/schema.gql
 server-nest/reports/
 ui-rs/target/
+ui-rs/crates/mines_mogwai/target/
 ui-rs/crates/mines_uirs/target/
 
 # dependencies
@@ -22,6 +23,7 @@ node_modules/
 coverage/
 
 # editors
+.vim-lsp-settings/settings.json
 .vscode/settings.json
 .idea/
 

--- a/server-nest/package.json
+++ b/server-nest/package.json
@@ -56,7 +56,7 @@
     "@types/pg": "7.14.9",
     "@types/supertest": "2.0.10",
     "@types/uuid": "8.3.0",
-    "faker": "5.2.0",
+    "faker": "5.3.1",
     "jest": "26.6.3",
     "supertest": "6.1.3",
     "ts-jest": "26.5.0",

--- a/server-nest/package.json
+++ b/server-nest/package.json
@@ -63,7 +63,7 @@
     "ts-node": "9.1.1",
     "tsconfig-paths": "3.9.0",
     "typescript": "4.1.3",
-    "webpack": "5.19.0"
+    "webpack": "5.21.1"
   },
   "jest": {
     "coverageDirectory": "<rootDir>/coverage",

--- a/server-nest/package.json
+++ b/server-nest/package.json
@@ -50,7 +50,7 @@
     "@stryker-mutator/jest-runner": "4.4.1",
     "@types/faker": "5.1.6",
     "@types/jest": "26.0.20",
-    "@types/node": "14.14.22",
+    "@types/node": "14.14.25",
     "@types/passport-jwt": "3.0.3",
     "@types/passport-local": "1.0.33",
     "@types/pg": "7.14.9",

--- a/server-nest/package.json
+++ b/server-nest/package.json
@@ -51,7 +51,7 @@
     "@types/faker": "5.1.6",
     "@types/jest": "26.0.20",
     "@types/node": "14.14.25",
-    "@types/passport-jwt": "3.0.3",
+    "@types/passport-jwt": "3.0.4",
     "@types/passport-local": "1.0.33",
     "@types/pg": "7.14.9",
     "@types/supertest": "2.0.10",

--- a/server-nest/package.json
+++ b/server-nest/package.json
@@ -22,11 +22,11 @@
   },
   "dependencies": {
     "@nearform/sql": "1.5.0",
-    "@nestjs/common": "7.6.8",
-    "@nestjs/core": "7.6.8",
+    "@nestjs/common": "7.6.11",
+    "@nestjs/core": "7.6.11",
     "@nestjs/jwt": "7.2.0",
     "@nestjs/passport": "7.1.5",
-    "@nestjs/platform-express": "7.6.8",
+    "@nestjs/platform-express": "7.6.11",
     "dotenv": "8.2.0",
     "elastic-apm-node": "3.10.0",
     "express": "4.17.1",
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@nestjs/cli": "7.5.4",
     "@nestjs/schematics": "7.2.7",
-    "@nestjs/testing": "7.6.8",
+    "@nestjs/testing": "7.6.11",
     "@stryker-mutator/core": "4.4.1",
     "@stryker-mutator/jest-runner": "4.4.1",
     "@types/faker": "5.1.6",

--- a/server-nest/package.json
+++ b/server-nest/package.json
@@ -30,7 +30,7 @@
     "dotenv": "8.2.0",
     "elastic-apm-node": "3.10.0",
     "express": "4.17.1",
-    "fp-ts": "2.9.3",
+    "fp-ts": "2.9.5",
     "io-ts": "2.2.13",
     "passport": "0.4.1",
     "passport-jwt": "4.0.0",

--- a/server-nest/package.json
+++ b/server-nest/package.json
@@ -31,7 +31,7 @@
     "elastic-apm-node": "3.10.0",
     "express": "4.17.1",
     "fp-ts": "2.9.5",
-    "io-ts": "2.2.13",
+    "io-ts": "2.2.14",
     "passport": "0.4.1",
     "passport-jwt": "4.0.0",
     "passport-local": "1.0.0",

--- a/server-nest/package.json
+++ b/server-nest/package.json
@@ -63,7 +63,7 @@
     "ts-node": "9.1.1",
     "tsconfig-paths": "3.9.0",
     "typescript": "4.1.3",
-    "webpack": "5.21.1"
+    "webpack": "5.21.2"
   },
   "jest": {
     "coverageDirectory": "<rootDir>/coverage",

--- a/ui-rs/Cargo.lock
+++ b/ui-rs/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "anyhow"
-version = "1.0.32"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b602bfe940d21c130f3895acd65221e8a61270debe89d628b9cb4e3ccb8569b"
+checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
 
 [[package]]
 name = "anymap"
@@ -103,6 +103,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501a375961cef1a0d44767200e66e4a559283097e91d0730b1d75dfb2f8a1494"
+dependencies = [
+ "log",
+ "web-sys",
+]
+
+[[package]]
 name = "dotenv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,8 +136,8 @@ checksum = "53e737a3522cd45f6adc19b644ce43ef53e1e9045f2d2de425c1f468abd4cf33"
 dependencies = [
  "dotenv",
  "proc-macro-hack",
- "proc-macro2 1.0.19",
- "quote 1.0.3",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -136,12 +146,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "futures"
-version = "0.1.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7e4c2612746b0df8fed4ce0c69156021b704c9aefa360311c04e6e9e002eed"
 
 [[package]]
 name = "futures"
@@ -198,8 +202,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a5081aa3de1f7542a794a397cde100ed903b0630152d0973479018fd85423a7"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.19",
- "quote 1.0.3",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -329,9 +333,9 @@ checksum = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
 
 [[package]]
 name = "js-sys"
-version = "0.3.45"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca059e81d9486668f12d455a4ea6daa600bd408134cd17e3d3fb5a32d1f016f8"
+checksum = "5cfb73131c35423a367daf8cbd24100af0d077668c8c2943f0e7dd775fef0f65"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -363,11 +367,11 @@ checksum = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
 
 [[package]]
 name = "log"
-version = "0.4.8"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -387,7 +391,7 @@ name = "mines_mogwai"
 version = "0.1.0"
 dependencies = [
  "console_error_panic_hook",
- "console_log",
+ "console_log 0.2.0",
  "dotenv_codegen",
  "log",
  "mogwai",
@@ -395,7 +399,7 @@ dependencies = [
  "serde_json",
  "uuid",
  "wasm-bindgen",
- "wasm-bindgen-futures 0.4.10",
+ "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "web-sys",
  "wee_alloc",
@@ -420,12 +424,12 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15136b42a21cdea725a5644d64a82a560b224bb56386dac2e30fbee2deb30cbf"
 dependencies = [
- "console_log",
+ "console_log 0.1.2",
  "js-sys",
  "log",
  "mogwai-html-macro",
  "wasm-bindgen",
- "wasm-bindgen-futures 0.4.10",
+ "wasm-bindgen-futures",
  "web-sys",
 ]
 
@@ -435,8 +439,8 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b1f082ace5ac528627ab8069556a3ed7ca5c69b0ba376f9d26cb11aa4a72101"
 dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.3",
+ "proc-macro2",
+ "quote",
  "syn",
  "syn-rsx",
 ]
@@ -472,29 +476,11 @@ checksum = "8e946095f9d3ed29ec38de908c22f95d9ac008e424c7bcae54c75a79c527c694"
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.30"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
+checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
- "unicode-xid 0.1.0",
-]
-
-[[package]]
-name = "proc-macro2"
-version = "1.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
-dependencies = [
- "unicode-xid 0.2.0",
-]
-
-[[package]]
-name = "quote"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-dependencies = [
- "proc-macro2 0.4.30",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -503,7 +489,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
 dependencies = [
- "proc-macro2 1.0.19",
+ "proc-macro2",
 ]
 
 [[package]]
@@ -520,21 +506,21 @@ checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
 name = "serde"
-version = "1.0.116"
+version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fe57af81d28386a513cbc6858332abc6117cfdb5999647c6444b8f43a370a5"
+checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.116"
+version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8"
+checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
 dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.3",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -563,13 +549,13 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
-version = "1.0.38"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e69abc24912995b3038597a7a593be5053eb0fb44f3cc5beec0deb421790c1f4"
+checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
 dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.3",
- "unicode-xid 0.2.0",
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -578,8 +564,8 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ff75cba682dea31200f91acf163a87f3dffc6406f14d0f7704c0b12d612af4"
 dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.3",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -598,16 +584,10 @@ version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
 dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.3",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
-
-[[package]]
-name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
 name = "unicode-xid"
@@ -639,11 +619,11 @@ checksum = "93c6c3420963c5c64bca373b25e77acb562081b9bb4dd5bb864187742186cea9"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.68"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42"
+checksum = "55c0f7123de74f0dab9b7d00fd614e7b19349cd1e2f5252bbe9b1754b59433be"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
@@ -651,39 +631,26 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.68"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f22b422e2a757c35a73774860af8e112bff612ce6cb604224e8e47641a9e4f68"
+checksum = "7bc45447f0d4573f3d65720f636bbcc3dd6ce920ed704670118650bcd47764c7"
 dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
- "proc-macro2 1.0.19",
- "quote 1.0.3",
+ "proc-macro2",
+ "quote",
  "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.3.27"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83420b37346c311b9ed822af41ec2e82839bfe99867ec6c54e2da43b7538771c"
+checksum = "3de431a2910c86679c34283a33f66f4e4abd7e0aec27b6669060148872aadf94"
 dependencies = [
- "cfg-if 0.1.10",
- "futures 0.1.30",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7add542ea1ac7fdaa9dc25e031a6af33b7d63376292bd24140c637d00d1c312a"
-dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -691,22 +658,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.68"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b13312a745c08c469f0b292dd2fcd6411dba5f7160f593da6ef69b64e407038"
+checksum = "3b8853882eef39593ad4174dd26fc9865a64e84026d223f63bb2c42affcbba2c"
 dependencies = [
- "quote 1.0.3",
+ "quote",
  "wasm-bindgen-macro-support",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.68"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
+checksum = "4133b5e7f2a531fa413b3a1695e925038a05a71cf67e87dafa295cb645a01385"
 dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.3",
+ "proc-macro2",
+ "quote",
  "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
@@ -714,33 +681,32 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.68"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d649a3145108d7d3fbcde896a468d1bd636791823c9921135218ad89be08307"
+checksum = "dd4945e4943ae02d15c13962b38a5b1e81eadd4b71214eee75af64a4d6a4fd64"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.2.50"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d9693b63a742d481c7f80587e057920e568317b2806988c59cd71618bc26c1"
+checksum = "f0d4da138503a4cf86801b94d95781ee3619faa8feca830569cc6b54997b8b5c"
 dependencies = [
  "console_error_panic_hook",
- "futures 0.1.30",
  "js-sys",
  "scoped-tls",
  "wasm-bindgen",
- "wasm-bindgen-futures 0.3.27",
+ "wasm-bindgen-futures",
  "wasm-bindgen-test-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.2.50"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0789dac148a8840bbcf9efe13905463b733fa96543bfbf263790535c11af7ba5"
+checksum = "c3199c33f06500c731d5544664c24d0c2b742b98debc6b1c6f0c6d6e8fb7c19b"
 dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -789,9 +755,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "yew"
-version = "0.17.3"
+version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882b275d108d2280dbc588a8ad6c9690d806fcd299d63b68d702ff4d848fdc0c"
+checksum = "2d8703eb5b883e816cd74c65e2f6dd4144eeedb77c1b3e0284e8f3f593b80ab1"
 dependencies = [
  "anyhow",
  "anymap",
@@ -799,7 +765,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "cfg-match",
  "console_error_panic_hook",
- "futures 0.3.4",
+ "futures",
  "gloo",
  "http",
  "indexmap",
@@ -813,7 +779,7 @@ dependencies = [
  "slab",
  "thiserror",
  "wasm-bindgen",
- "wasm-bindgen-futures 0.4.10",
+ "wasm-bindgen-futures",
  "web-sys",
  "yew-macro",
 ]
@@ -827,8 +793,8 @@ dependencies = [
  "boolinator",
  "lazy_static",
  "proc-macro-hack",
- "proc-macro2 1.0.19",
- "quote 1.0.3",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -859,8 +825,8 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "768693f16c930d8a8742c2e5f62f258d5a6f0392e8c9265a45c550fac4cbe5a7"
 dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.3",
+ "proc-macro2",
+ "quote",
  "syn",
  "yew-router-route-parser",
 ]

--- a/ui-rs/Cargo.lock
+++ b/ui-rs/Cargo.lock
@@ -526,9 +526,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.61"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
+checksum = "ea1c6153794552ea7cf7cf63b1231a25de00ec90db326ba6264440fa08e31486"
 dependencies = [
  "itoa",
  "ryu",

--- a/ui-rs/crates/mines_mogwai/Cargo.toml
+++ b/ui-rs/crates/mines_mogwai/Cargo.toml
@@ -19,11 +19,11 @@ default = ["console_error_panic_hook"]
 [dependencies]
 console_log = "0.2.0"
 dotenv_codegen = "0.15.0"
-log = "0.4.13"
+log = "0.4.14"
 mogwai = "0.4.0"
-serde = { version = "1.0.120", features = ["derive"] }
-serde_json = "1.0.61"
-wasm-bindgen-futures = "0.4.19"
+serde = { version = "1.0.123", features = ["derive"] }
+serde_json = "1.0.62"
+wasm-bindgen-futures = "0.4.20"
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires
 # all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
@@ -45,7 +45,7 @@ features = [
 ]
 
 [dependencies.wasm-bindgen]
-version = "0.2.69"
+version = "0.2.70"
 features = [
   "serde-serialize"
 ]
@@ -65,4 +65,4 @@ features = [
 ]
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3.19"
+wasm-bindgen-test = "0.3.20"

--- a/ui-rs/crates/mines_mogwai/Cargo.toml
+++ b/ui-rs/crates/mines_mogwai/Cargo.toml
@@ -17,13 +17,13 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-console_log = "0.1.2"
+console_log = "0.2.0"
 dotenv_codegen = "0.15.0"
-log = "0.4.8"
+log = "0.4.13"
 mogwai = "0.4.0"
-serde = { version = "1.0.116", features = ["derive"] }
+serde = { version = "1.0.120", features = ["derive"] }
 serde_json = "1.0.61"
-wasm-bindgen-futures = "0.4.10"
+wasm-bindgen-futures = "0.4.19"
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires
 # all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
@@ -34,7 +34,7 @@ console_error_panic_hook = { version = "0.1.6", optional = true }
 # allocator, however.
 #
 # Unfortunately, `wee_alloc` requires nightly Rust when targeting wasm for now.
-wee_alloc = { version = "0.4.2", optional = true }
+wee_alloc = { version = "0.4.5", optional = true }
 
 [dependencies.uuid]
 version = "0.8"
@@ -45,7 +45,7 @@ features = [
 ]
 
 [dependencies.wasm-bindgen]
-version = "0.2.68"
+version = "0.2.69"
 features = [
   "serde-serialize"
 ]
@@ -65,4 +65,4 @@ features = [
 ]
 
 [dev-dependencies]
-wasm-bindgen-test = "0.2"
+wasm-bindgen-test = "0.3.19"

--- a/ui-rs/crates/mines_mogwai/src/routes/game.rs
+++ b/ui-rs/crates/mines_mogwai/src/routes/game.rs
@@ -1,6 +1,9 @@
 use crate::{api, components};
 use mogwai::prelude::*;
 
+/// Create a game screen for the game referenced by the provided `api::GameId`. Set up the game
+/// screen and display a game board. The board will display as empty until game information can be
+/// retrieved from the API.
 #[allow(unused_braces)]
 pub fn game(game_id: api::GameId) -> ViewBuilder<HtmlElement> {
     use components::game::CellInteract;

--- a/ui-rs/crates/mines_mogwai/src/routes/game.rs
+++ b/ui-rs/crates/mines_mogwai/src/routes/game.rs
@@ -6,16 +6,14 @@ use mogwai::prelude::*;
 /// retrieved from the API.
 #[allow(unused_braces)]
 pub fn game(game_id: api::GameId) -> ViewBuilder<HtmlElement> {
-    use components::game::CellInteract;
     // Create a transmitter to send button clicks into.
     let tx_game: Transmitter<api::GameState> = Transmitter::new();
-    let tx_cells: Transmitter<CellInteract> = Transmitter::new();
+    let tx_cells: Transmitter<components::game::CellInteract> = Transmitter::new();
     // Create the upstream `Transmitter` for `tx_game` (i.e. messages sent to `tx_api` will be
     // passed to `tx_game` if the response is success.
-    use api::{FetchError, GameState};
     let tx_api = tx_game.contra_filter_fold(
         None,
-        |current: &mut Option<GameState>, r: &Result<GameState, FetchError>| {
+        |current: &mut Option<api::GameState>, r: &Result<api::GameState, api::FetchError>| {
             if let Ok(next) = r {
                 current.replace(next.clone());
             }
@@ -54,14 +52,15 @@ fn game_board(
     tx_game: &Transmitter<api::GameState>,
     tx_cells: Transmitter<components::game::CellInteract>,
 ) -> ViewBuilder<HtmlElement> {
-    use components::game::CellUpdate;
     let rx_game_board = Receiver::new();
-    tx_game.wire_map(&rx_game_board, |game_state| CellUpdate::All {
-        cells: game_state.board.clone(),
+    tx_game.wire_map(&rx_game_board, |game_state| {
+        components::game::CellUpdate::All {
+            cells: game_state.board.clone(),
+        }
     });
     // Patch the initial board state into the game board slot
     let rx_patch_game = rx_game_board.branch_filter_map(move |update| match update {
-        CellUpdate::All { cells } => Some(Patch::Replace {
+        components::game::CellUpdate::All { cells } => Some(Patch::Replace {
             index: 0,
             value: components::game::board(cells.clone(), &tx_cells),
         }),

--- a/ui-rs/crates/mines_uirs/Cargo.toml
+++ b/ui-rs/crates/mines_uirs/Cargo.toml
@@ -14,10 +14,10 @@ license = "MIT"
 crate-type = ["cdylib"]
 
 [dependencies]
-anyhow = "1.0.32"
+anyhow = "1.0.38"
 dotenv_codegen = "0.15.0"
-serde = "1.0.116"
-serde_json = "1.0.58"
-yew = "0.17.3"
+serde = "1.0.120"
+serde_json = "1.0.61"
+yew = "0.17.4"
 yew-router = "0.14.0"
-wasm-bindgen = "0.2.68"
+wasm-bindgen = "0.2.69"

--- a/ui-rs/crates/mines_uirs/Cargo.toml
+++ b/ui-rs/crates/mines_uirs/Cargo.toml
@@ -16,8 +16,8 @@ crate-type = ["cdylib"]
 [dependencies]
 anyhow = "1.0.38"
 dotenv_codegen = "0.15.0"
-serde = "1.0.120"
-serde_json = "1.0.61"
+serde = "1.0.123"
+serde_json = "1.0.62"
 yew = "0.17.4"
 yew-router = "0.14.0"
-wasm-bindgen = "0.2.69"
+wasm-bindgen = "0.2.70"

--- a/ui-rs/package.json
+++ b/ui-rs/package.json
@@ -21,7 +21,7 @@
     "ts-node": "9.1.1",
     "typescript": "4.1.3",
     "url-loader": "4.1.1",
-    "webpack": "5.21.1",
+    "webpack": "5.21.2",
     "webpack-cli": "4.5.0",
     "webpack-dev-server": "3.11.2"
   }

--- a/ui-rs/package.json
+++ b/ui-rs/package.json
@@ -15,14 +15,14 @@
   },
   "devDependencies": {
     "css-loader": "5.0.1",
-    "html-webpack-plugin": "5.0.0-beta.6",
+    "html-webpack-plugin": "5.0.0",
     "mini-css-extract-plugin": "1.3.5",
     "ts-loader": "8.0.14",
     "ts-node": "9.1.1",
     "typescript": "4.1.3",
     "url-loader": "4.1.1",
-    "webpack": "5.19.0",
-    "webpack-cli": "4.4.0",
+    "webpack": "5.21.1",
+    "webpack-cli": "4.5.0",
     "webpack-dev-server": "3.11.2"
   }
 }

--- a/ui-rs/package.json
+++ b/ui-rs/package.json
@@ -17,7 +17,7 @@
     "css-loader": "5.0.1",
     "html-webpack-plugin": "5.0.0",
     "mini-css-extract-plugin": "1.3.5",
-    "ts-loader": "8.0.14",
+    "ts-loader": "8.0.15",
     "ts-node": "9.1.1",
     "typescript": "4.1.3",
     "url-loader": "4.1.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@babel/helper-call-delegate": "7.12.13",
-    "fp-ts": "2.9.3",
+    "fp-ts": "2.9.5",
     "isomorphic-unfetch": "3.1.0",
     "next": "10.0.6",
     "react": "17.0.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@types/node": "14.14.25",
-    "@types/react": "17.0.0",
+    "@types/react": "17.0.1",
     "eslint": "7.19.0",
     "eslint-plugin-react": "7.22.0",
     "typescript": "4.1.3"

--- a/ui/package.json
+++ b/ui/package.json
@@ -23,7 +23,7 @@
     "react-dom": "17.0.1"
   },
   "devDependencies": {
-    "@types/node": "14.14.22",
+    "@types/node": "14.14.25",
     "@types/react": "17.0.0",
     "eslint": "7.19.0",
     "eslint-plugin-react": "7.22.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -15,7 +15,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@babel/helper-call-delegate": "7.12.1",
+    "@babel/helper-call-delegate": "7.12.13",
     "fp-ts": "2.9.3",
     "isomorphic-unfetch": "3.1.0",
     "next": "10.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -966,7 +966,7 @@ __metadata:
     "@stryker-mutator/jest-runner": 4.4.1
     "@types/faker": 5.1.6
     "@types/jest": 26.0.20
-    "@types/node": 14.14.22
+    "@types/node": 14.14.25
     "@types/passport-jwt": 3.0.3
     "@types/passport-local": 1.0.33
     "@types/pg": 7.14.9
@@ -1002,7 +1002,7 @@ __metadata:
   resolution: "@mines/ui@workspace:ui"
   dependencies:
     "@babel/helper-call-delegate": 7.12.13
-    "@types/node": 14.14.22
+    "@types/node": 14.14.25
     "@types/react": 17.0.0
     eslint: 7.19.0
     eslint-plugin-react: 7.22.0
@@ -1665,10 +1665,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:14.14.22":
+"@types/node@npm:*":
   version: 14.14.22
   resolution: "@types/node@npm:14.14.22"
   checksum: e46e32685b4d0261779c13c10ba3ff220cfa714b5c12f8f571fd52cc309546bdbc8ffc86cbad20559ad88e7b17e66fc51c98b067d8c3766597092c05df157b9b
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:14.14.25":
+  version: 14.14.25
+  resolution: "@types/node@npm:14.14.25"
+  checksum: 64c42730f4169e49ec378870622ef06c5d820b31340e224cc1b45bf06c8b0cfa28daa587b4ae2b8ea1f712ef049bae4d9c92925b157ba9ba7cde3b22ff552513
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -993,7 +993,7 @@ __metadata:
     typescript: 4.1.3
     ulid: 2.3.0
     uuid: 8.3.2
-    webpack: 5.19.0
+    webpack: 5.21.1
   languageName: unknown
   linkType: soft
 
@@ -1020,14 +1020,14 @@ __metadata:
   resolution: "@mines/uirs@workspace:ui-rs"
   dependencies:
     css-loader: 5.0.1
-    html-webpack-plugin: 5.0.0-beta.6
+    html-webpack-plugin: 5.0.0
     mini-css-extract-plugin: 1.3.5
     ts-loader: 8.0.14
     ts-node: 9.1.1
     typescript: 4.1.3
     url-loader: 4.1.1
-    webpack: 5.19.0
-    webpack-cli: 4.4.0
+    webpack: 5.21.1
+    webpack-cli: 4.5.0
     webpack-dev-server: 3.11.2
   languageName: unknown
   linkType: soft
@@ -2322,36 +2322,36 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webpack-cli/configtest@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@webpack-cli/configtest@npm:1.0.0"
+"@webpack-cli/configtest@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@webpack-cli/configtest@npm:1.0.1"
   peerDependencies:
     webpack: 4.x.x || 5.x.x
     webpack-cli: 4.x.x
-  checksum: 7aac463cd48f42c523e4d5af540cdb00cb5ff867c471160e0c96845db5b3ec80f4c572128bd6911f2954507ee4a5b8aaa983a427b3a053a09d20743ced59a549
+  checksum: 6db91531c43658c7830767cd698e72dd2d569d85b306a9eedafc1d8a8935b0a9ecf3881b7fff21eca18695c3440e911f2020fa7b9ea29af41944f23efa54bd16
   languageName: node
   linkType: hard
 
-"@webpack-cli/info@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "@webpack-cli/info@npm:1.2.1"
+"@webpack-cli/info@npm:^1.2.2":
+  version: 1.2.2
+  resolution: "@webpack-cli/info@npm:1.2.2"
   dependencies:
     envinfo: ^7.7.3
   peerDependencies:
     webpack-cli: 4.x.x
-  checksum: 5d7533ed5a2b3cf5429730661b1dba47f96a3ee9a4f87fc4bbf889fac28a603bc73d4ee143df4cf5cd3e4e91d91ad6bfdfb76a786d346265f7a193c3612582e6
+  checksum: ee23161d9ea56be871e67596f9d65b8342de858b59cb6658870bda474deaa328ea0d34320344eac704b88673a373456584e08748f0a7d60226bf76c2e667e706
   languageName: node
   linkType: hard
 
-"@webpack-cli/serve@npm:^1.2.2":
-  version: 1.2.2
-  resolution: "@webpack-cli/serve@npm:1.2.2"
+"@webpack-cli/serve@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "@webpack-cli/serve@npm:1.3.0"
   peerDependencies:
     webpack-cli: 4.x.x
   peerDependenciesMeta:
     webpack-dev-server:
       optional: true
-  checksum: 86dab170ba2f516e56005bc9a58d7e8c453064b897ed11fe18db23e02e69642ff61a9682e53593471285f3122eef276a46ee54ffb3c1a9608f073e28dc4e39f7
+  checksum: ce97bd9db98663375d62edbcd5711e057291e890c9e89254e4333fb9e6192252afca743b8a0fa087be00c6222db1c2e1d4da67707c6a679e1d9e1d7a3d001381
   languageName: node
   linkType: hard
 
@@ -3919,14 +3919,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:^6.2.0":
-  version: 6.2.1
-  resolution: "commander@npm:6.2.1"
-  checksum: 47856aae6f194404122e359d8463e5e1a18f7cbab26722ce69f1379be8514bd49a160ef81a983d3d2091e3240022643354101d1276c797dcdd0b5bfc3c3f04a3
-  languageName: node
-  linkType: hard
-
-"commander@npm:~7.0.0":
+"commander@npm:^7.0.0, commander@npm:~7.0.0":
   version: 7.0.0
   resolution: "commander@npm:7.0.0"
   checksum: 46e60cb1e1ccc3e8d4bac5672d4be08cb60d0a0c22d0c352ba9f9713a11996e79a67216ace4dc32a04ee621c86c9a327f0c35126e4aaf3ede3004f78a009cb19
@@ -6565,9 +6558,9 @@ fsevents@~2.3.1:
   languageName: node
   linkType: hard
 
-"html-webpack-plugin@npm:5.0.0-beta.6":
-  version: 5.0.0-beta.6
-  resolution: "html-webpack-plugin@npm:5.0.0-beta.6"
+"html-webpack-plugin@npm:5.0.0":
+  version: 5.0.0
+  resolution: "html-webpack-plugin@npm:5.0.0"
   dependencies:
     "@types/html-minifier-terser": ^5.0.0
     html-minifier-terser: ^5.0.1
@@ -6576,8 +6569,8 @@ fsevents@~2.3.1:
     pretty-error: ^2.1.1
     tapable: ^2.0.0
   peerDependencies:
-    webpack: ^5.1.2
-  checksum: 51e402f6bb6e479bab6a7c919effeb73dad73917b085c263244003fe6f2932c8c7110a5d95d2125b10cdab9cce354db394ef4b99bcfc6040ad929db3a3f917e8
+    webpack: ^5.20.0
+  checksum: 2b72c3639d220d0ca3b858b355905dc0df2410722c568fb8fb1814ad157f4a3726e35440783d19bc5353c130a0607afad199580fe85257883bf5e110f943a745
   languageName: node
   linkType: hard
 
@@ -13477,16 +13470,16 @@ typescript@4.1.3:
   languageName: node
   linkType: hard
 
-"webpack-cli@npm:4.4.0":
-  version: 4.4.0
-  resolution: "webpack-cli@npm:4.4.0"
+"webpack-cli@npm:4.5.0":
+  version: 4.5.0
+  resolution: "webpack-cli@npm:4.5.0"
   dependencies:
     "@discoveryjs/json-ext": ^0.5.0
-    "@webpack-cli/configtest": ^1.0.0
-    "@webpack-cli/info": ^1.2.1
-    "@webpack-cli/serve": ^1.2.2
+    "@webpack-cli/configtest": ^1.0.1
+    "@webpack-cli/info": ^1.2.2
+    "@webpack-cli/serve": ^1.3.0
     colorette: ^1.2.1
-    commander: ^6.2.0
+    commander: ^7.0.0
     enquirer: ^2.3.6
     execa: ^5.0.0
     fastest-levenshtein: ^1.0.12
@@ -13510,7 +13503,7 @@ typescript@4.1.3:
       optional: true
   bin:
     webpack-cli: bin/cli.js
-  checksum: 0d1328369a1babcb5e90896d9579c13c18696f283e92feb29131fa9d64986e4359df37772a2a3ec15159b89efe5ab2ad77d16e2b735a458d10bb729aeadcecbc
+  checksum: dde382455aa3af9f38b48bfa85d4e3df39766b9478e7457e69b415bd96c30747fe8a16d2405be8a59654e9bbdd3b03296a75d8bdab1b7f2a3fda2028f4683568
   languageName: node
   linkType: hard
 
@@ -13624,9 +13617,9 @@ typescript@4.1.3:
   languageName: node
   linkType: hard
 
-"webpack@npm:5.19.0":
-  version: 5.19.0
-  resolution: "webpack@npm:5.19.0"
+"webpack@npm:5.21.1":
+  version: 5.21.1
+  resolution: "webpack@npm:5.21.1"
   dependencies:
     "@types/eslint-scope": ^3.7.0
     "@types/estree": ^0.0.46
@@ -13646,7 +13639,6 @@ typescript@4.1.3:
     loader-runner: ^4.2.0
     mime-types: ^2.1.27
     neo-async: ^2.6.2
-    pkg-dir: ^5.0.0
     schema-utils: ^3.0.0
     tapable: ^2.1.1
     terser-webpack-plugin: ^5.1.1
@@ -13657,7 +13649,7 @@ typescript@4.1.3:
       optional: true
   bin:
     webpack: bin/webpack.js
-  checksum: db179047c437b1e2880a818f0e674f7988ad1f622f270e109a3531742d89254f1b042678d7cb7e4662519c834d842c81eb21cb1e53b020e57792a99bf66944a8
+  checksum: 8f2dcd43d359451d4fba313f23f52ab79df82fd191a3540e8ecc8ca38bb27c8cc44d285a324dcfa7656a5b2ec6c41bc372423e3c9d5b87fccf5bc2f1ad673ffc
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1003,7 +1003,7 @@ __metadata:
   dependencies:
     "@babel/helper-call-delegate": 7.12.13
     "@types/node": 14.14.25
-    "@types/react": 17.0.0
+    "@types/react": 17.0.1
     eslint: 7.19.0
     eslint-plugin-react: 7.22.0
     fp-ts: 2.9.3
@@ -1772,13 +1772,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:17.0.0":
-  version: 17.0.0
-  resolution: "@types/react@npm:17.0.0"
+"@types/react@npm:17.0.1":
+  version: 17.0.1
+  resolution: "@types/react@npm:17.0.1"
   dependencies:
     "@types/prop-types": "*"
     csstype: ^3.0.2
-  checksum: dcef2034b822a949c5528fa8fa3c64da654fdbb822bd8f0488c0084d84cadb8b90af68813a6c95153d4754079f50b1cab206552c7c20f6b67a26c3641383fe31
+  checksum: 5b490728c5210ea20b20377dd8c69b12ba7283058788d431d8b35ff4d18d03aa3a0f0cc6fe83691c8b9707d3e7ee8e9aae4e50d3989e094c907030d045d0e4e2
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -180,13 +180,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-call-delegate@npm:7.12.1":
-  version: 7.12.1
-  resolution: "@babel/helper-call-delegate@npm:7.12.1"
+"@babel/helper-call-delegate@npm:7.12.13":
+  version: 7.12.13
+  resolution: "@babel/helper-call-delegate@npm:7.12.13"
   dependencies:
-    "@babel/helper-hoist-variables": ^7.10.4
-    "@babel/types": ^7.12.1
-  checksum: 0b01b03bfc6983e9c8275373df32a41a9af94530ada27d8ae03996dbd42a600638ab35176dadc3e9a7655b3d5b00b1f08265e4af83ccfdc3649ad6d388f876a1
+    "@babel/helper-hoist-variables": ^7.12.13
+    "@babel/types": ^7.12.13
+  checksum: aaf0d662643e68a066200a8c4be2f86b815ed17f088360d714b32be08c364760b1024ce7248f5d92e5fec1d38278384a237518053c95bbebbbc37309ea048a5b
   languageName: node
   linkType: hard
 
@@ -225,12 +225,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-hoist-variables@npm:^7.10.4":
-  version: 7.10.4
-  resolution: "@babel/helper-hoist-variables@npm:7.10.4"
+"@babel/helper-hoist-variables@npm:^7.12.13":
+  version: 7.12.13
+  resolution: "@babel/helper-hoist-variables@npm:7.12.13"
   dependencies:
-    "@babel/types": ^7.10.4
-  checksum: 0bc1976366e1535920ac46ecf89700a738bb38f1413ca42f1bc11bef708f297f011078077355dfe81b3e5af8ef696c5fb752408d6b65f85c71839c28ce95afaa
+    "@babel/types": ^7.12.13
+  checksum: dc3cc7d1e15c6befbb196c6ce5a758b6a27eda41243401281c192607c00ac785083a3a6383b68be130d505d1e71563946f299b33935ae9e12865abb03cad1f36
   languageName: node
   linkType: hard
 
@@ -643,6 +643,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/types@npm:^7.12.13":
+  version: 7.12.13
+  resolution: "@babel/types@npm:7.12.13"
+  dependencies:
+    "@babel/helper-validator-identifier": ^7.12.11
+    lodash: ^4.17.19
+    to-fast-properties: ^2.0.0
+  checksum: b6bb1356a7f3737a03c9362df03fd08a2b0599d117169cf7e2e856551fdf01cf4d5188d6370b23315f196058b0239fd609b65ccadcfed3bb3c0b90c27575e805
+  languageName: node
+  linkType: hard
+
 "@babel/types@npm:^7.8.3":
   version: 7.12.12
   resolution: "@babel/types@npm:7.12.12"
@@ -990,7 +1001,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@mines/ui@workspace:ui"
   dependencies:
-    "@babel/helper-call-delegate": 7.12.1
+    "@babel/helper-call-delegate": 7.12.13
     "@types/node": 14.14.22
     "@types/react": 17.0.0
     eslint: 7.19.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -976,7 +976,7 @@ __metadata:
     elastic-apm-node: 3.10.0
     express: 4.17.1
     faker: 5.3.1
-    fp-ts: 2.9.3
+    fp-ts: 2.9.5
     io-ts: 2.2.13
     jest: 26.6.3
     passport: 0.4.1
@@ -1006,7 +1006,7 @@ __metadata:
     "@types/react": 17.0.1
     eslint: 7.19.0
     eslint-plugin-react: 7.22.0
-    fp-ts: 2.9.3
+    fp-ts: 2.9.5
     isomorphic-unfetch: 3.1.0
     next: 10.0.6
     react: 17.0.1
@@ -6012,10 +6012,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fp-ts@npm:2.9.3":
-  version: 2.9.3
-  resolution: "fp-ts@npm:2.9.3"
-  checksum: d32ea0a319fa50f8760aabf455da4d633f3736cec284b44fc11ba28362a9b51912a15c5ffea415f31f04bbedddd009b15e4547d8b67cda171a43c59c033497c1
+"fp-ts@npm:2.9.5":
+  version: 2.9.5
+  resolution: "fp-ts@npm:2.9.5"
+  checksum: de7dfc21068ad4254b05f558c67b3abafc442b7756933b0932d0de593cf172c0d52a38bd8eab4c19ab1a7c33ac6c3a1d4f8723dcf3cdbee01c3f7e1d3199b793
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -993,7 +993,7 @@ __metadata:
     typescript: 4.1.3
     ulid: 2.3.0
     uuid: 8.3.2
-    webpack: 5.21.1
+    webpack: 5.21.2
   languageName: unknown
   linkType: soft
 
@@ -1026,7 +1026,7 @@ __metadata:
     ts-node: 9.1.1
     typescript: 4.1.3
     url-loader: 4.1.1
-    webpack: 5.21.1
+    webpack: 5.21.2
     webpack-cli: 4.5.0
     webpack-dev-server: 3.11.2
   languageName: unknown
@@ -13617,9 +13617,9 @@ typescript@4.1.3:
   languageName: node
   linkType: hard
 
-"webpack@npm:5.21.1":
-  version: 5.21.1
-  resolution: "webpack@npm:5.21.1"
+"webpack@npm:5.21.2":
+  version: 5.21.2
+  resolution: "webpack@npm:5.21.2"
   dependencies:
     "@types/eslint-scope": ^3.7.0
     "@types/estree": ^0.0.46
@@ -13649,7 +13649,7 @@ typescript@4.1.3:
       optional: true
   bin:
     webpack: bin/webpack.js
-  checksum: 8f2dcd43d359451d4fba313f23f52ab79df82fd191a3540e8ecc8ca38bb27c8cc44d285a324dcfa7656a5b2ec6c41bc372423e3c9d5b87fccf5bc2f1ad673ffc
+  checksum: 0f8ec63a22a9c6a347e97e6a511f87d00f0f20abf7b62b8147de84325396f5192202e3c83f8fbad95fa7f9c35604e5a3cb5264f7ae58009ba5d9520dce04a76b
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -977,7 +977,7 @@ __metadata:
     express: 4.17.1
     faker: 5.3.1
     fp-ts: 2.9.5
-    io-ts: 2.2.13
+    io-ts: 2.2.14
     jest: 26.6.3
     passport: 0.4.1
     passport-jwt: 4.0.0
@@ -6959,12 +6959,12 @@ fsevents@~2.3.1:
   languageName: node
   linkType: hard
 
-"io-ts@npm:2.2.13":
-  version: 2.2.13
-  resolution: "io-ts@npm:2.2.13"
+"io-ts@npm:2.2.14":
+  version: 2.2.14
+  resolution: "io-ts@npm:2.2.14"
   peerDependencies:
     fp-ts: ^2.0.0
-  checksum: 93265e16eaafe56bbb4a8789d9a8fecb0b22c2e55c917c3c0f5c55de20bbe2ff27e5bc1718d615bb892c01c397edcc7907babbc1e7571e3fc169bb30032f6da5
+  checksum: 9a874b38b11d88654bf374e7f34fdc47243f681b2ac1c0c7c21deb364afb8dba001f3b2eb2ee1dd596477137724614a6a55670b0200f0a7beeed15c774f728de
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -955,13 +955,13 @@ __metadata:
   dependencies:
     "@nearform/sql": 1.5.0
     "@nestjs/cli": 7.5.4
-    "@nestjs/common": 7.6.8
-    "@nestjs/core": 7.6.8
+    "@nestjs/common": 7.6.11
+    "@nestjs/core": 7.6.11
     "@nestjs/jwt": 7.2.0
     "@nestjs/passport": 7.1.5
-    "@nestjs/platform-express": 7.6.8
+    "@nestjs/platform-express": 7.6.11
     "@nestjs/schematics": 7.2.7
-    "@nestjs/testing": 7.6.8
+    "@nestjs/testing": 7.6.11
     "@stryker-mutator/core": 4.4.1
     "@stryker-mutator/jest-runner": 4.4.1
     "@types/faker": 5.1.6
@@ -1071,9 +1071,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nestjs/common@npm:7.6.8":
-  version: 7.6.8
-  resolution: "@nestjs/common@npm:7.6.8"
+"@nestjs/common@npm:7.6.11":
+  version: 7.6.11
+  resolution: "@nestjs/common@npm:7.6.11"
   dependencies:
     axios: 0.21.1
     iterare: 1.2.1
@@ -1092,13 +1092,13 @@ __metadata:
       optional: true
     class-validator:
       optional: true
-  checksum: 166c78c040ef45fd90c822ff38e52f9569a36a1f20549ab6ebfbb148f3146db1297aa4893d6423eb5f79839dbc9cbf3cb78db244004abb1012400a9bd5fafc37
+  checksum: 681044546333db7aa95c6558f2eb72816118facbd3b043f9a006db3006b72d01439e2bc761c9598bfbd51595297fbf5785accc5ced39e2dd4fc30351335f7d02
   languageName: node
   linkType: hard
 
-"@nestjs/core@npm:7.6.8":
-  version: 7.6.8
-  resolution: "@nestjs/core@npm:7.6.8"
+"@nestjs/core@npm:7.6.11":
+  version: 7.6.11
+  resolution: "@nestjs/core@npm:7.6.11"
   dependencies:
     "@nuxtjs/opencollective": 0.3.2
     fast-safe-stringify: 2.0.7
@@ -1121,7 +1121,7 @@ __metadata:
       optional: true
     "@nestjs/websockets":
       optional: true
-  checksum: 0e5dd7bf519ceed51981ec7c9ce36fe22fdac083780b8a0c310ad67a62814d8a93a3803bff24600435cca6c17c98186c8575767f1b30609e4e27c7145795df2d
+  checksum: a7e4ccf42605513a6287ce72d6f85aebc5cd68f60449ec7b7815d56871276ca4c5a1bfabe125f7ba364ac599e1a398fe51043ab747fe175338783bc7e637e12f
   languageName: node
   linkType: hard
 
@@ -1147,9 +1147,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nestjs/platform-express@npm:7.6.8":
-  version: 7.6.8
-  resolution: "@nestjs/platform-express@npm:7.6.8"
+"@nestjs/platform-express@npm:7.6.11":
+  version: 7.6.11
+  resolution: "@nestjs/platform-express@npm:7.6.11"
   dependencies:
     body-parser: 1.19.0
     cors: 2.8.5
@@ -1159,7 +1159,7 @@ __metadata:
   peerDependencies:
     "@nestjs/common": ^7.0.0
     "@nestjs/core": ^7.0.0
-  checksum: 84752f7e5b8e9f993f318ee4e4e9e41d18968898515f1e2cb366a6cf227999caca380bab748c7f7cebd0d384c2c6aea99e5892ec220ebefd506f03c207094621
+  checksum: 2dadc955533e1284b566a8c8035066f21d3ef7e3a597b1d85724a131bdfb959a4ed6559e61091fd49593be7d145bc4c51a83bf8ffacbd5cf2d2dffa02a625805
   languageName: node
   linkType: hard
 
@@ -1177,9 +1177,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nestjs/testing@npm:7.6.8":
-  version: 7.6.8
-  resolution: "@nestjs/testing@npm:7.6.8"
+"@nestjs/testing@npm:7.6.11":
+  version: 7.6.11
+  resolution: "@nestjs/testing@npm:7.6.11"
   dependencies:
     optional: 0.1.4
     tslib: 2.1.0
@@ -1193,7 +1193,7 @@ __metadata:
       optional: true
     "@nestjs/platform-express":
       optional: true
-  checksum: dbad8cf3222285d0f02432aa5680fa922ab07dbf05d995c8c67ff061845a3c5765f8e36c0ffa0bba3b5809b827df719c24168083e27519fe57914a12018234a8
+  checksum: 0840b381228690a10aab99ec1d8224154dc7286fc4c9fef862ec8c0423490adfa210c29423912559f304667c33b6c131f93080e089cc8bb71e24da5cd0252116
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -967,7 +967,7 @@ __metadata:
     "@types/faker": 5.1.6
     "@types/jest": 26.0.20
     "@types/node": 14.14.25
-    "@types/passport-jwt": 3.0.3
+    "@types/passport-jwt": 3.0.4
     "@types/passport-local": 1.0.33
     "@types/pg": 7.14.9
     "@types/supertest": 2.0.10
@@ -1693,14 +1693,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/passport-jwt@npm:3.0.3":
-  version: 3.0.3
-  resolution: "@types/passport-jwt@npm:3.0.3"
+"@types/passport-jwt@npm:3.0.4":
+  version: 3.0.4
+  resolution: "@types/passport-jwt@npm:3.0.4"
   dependencies:
     "@types/express": "*"
     "@types/jsonwebtoken": "*"
     "@types/passport-strategy": "*"
-  checksum: 929b0caa5b071f3ceafb6832316f6706b21eab39148913fa1735ffd3d2a8c21eda61a4e44fe6cbb217d4baad7d2b460e6f6ec16994cbafb7ffb6fb5d757cf6a2
+  checksum: 4220e5f57394ff5a3d557b67ef94ba754b7e90248386b10d1207758e2c5f93f8b27617d2877bae27399a1d42f396e8b1684d295de6e2991271a0bec2d2112afa
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1022,7 +1022,7 @@ __metadata:
     css-loader: 5.0.1
     html-webpack-plugin: 5.0.0
     mini-css-extract-plugin: 1.3.5
-    ts-loader: 8.0.14
+    ts-loader: 8.0.15
     ts-node: 9.1.1
     typescript: 4.1.3
     url-loader: 4.1.1
@@ -12830,9 +12830,9 @@ fsevents@~2.3.1:
   languageName: node
   linkType: hard
 
-"ts-loader@npm:8.0.14":
-  version: 8.0.14
-  resolution: "ts-loader@npm:8.0.14"
+"ts-loader@npm:8.0.15":
+  version: 8.0.15
+  resolution: "ts-loader@npm:8.0.15"
   dependencies:
     chalk: ^4.1.0
     enhanced-resolve: ^4.0.0
@@ -12842,7 +12842,7 @@ fsevents@~2.3.1:
   peerDependencies:
     typescript: "*"
     webpack: "*"
-  checksum: 7ccab1af8632370d777733e19821eb304c069cd56cc5246cbc59b6544ffc1d3f1431dd81904491105dfae7335a818563217af4ac715965dcff26b97ce1a44c63
+  checksum: bf47ef147ae56af9d4e1c3ed2eb43815c850ed04524a4b2043b5f679fd92859016323521a76c62bea42391242da9dd1da8dd0e5ec8f7158e6206b9d97ff90b43
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -975,7 +975,7 @@ __metadata:
     dotenv: 8.2.0
     elastic-apm-node: 3.10.0
     express: 4.17.1
-    faker: 5.2.0
+    faker: 5.3.1
     fp-ts: 2.9.3
     io-ts: 2.2.13
     jest: 26.6.3
@@ -5692,10 +5692,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"faker@npm:5.2.0":
-  version: 5.2.0
-  resolution: "faker@npm:5.2.0"
-  checksum: 425bb97cadb50c79a25cee166082d5292c4a4a7bfae599f9ef301de1fb4c530c34d96a747173a30d3949491c4ff15590e7c4d71b2ed7fc1e8d7b68e300a0b602
+"faker@npm:5.3.1":
+  version: 5.3.1
+  resolution: "faker@npm:5.3.1"
+  checksum: 40f3e92fe392f4269d5891b85ab787e1049fd2dfceb51e703a8142dc1a02aeb823b1beef986f0222eb17eac3968474cdc90a9d6128440b5b14be4df20391d731
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Node

- Update `ts-loader` from 8.0.14 to 8.0.15
- Update `io-ts` from 2.2.13 to 2.2.14
- Update `html-webpack-plugin` from 5.0.0-beta.6 to 5.0.0
- Update `webpack` from 5.19.0 to 5.21.2
- Update `webpack-cli` from 4.4.0 to 4.5.0
- Update `fp-ts` from 2.9.3 to 2.9.5
- Update `faker` from 5.2.0 to 5.3.1
- Update `@types/react` from 17.0.0 to 17.0.1
- Update `@types/passport-jwt` from 3.0.3 to 3.0.4
- Update `@types/node` from 14.14.22 to 14.14.25
- Update `@nestjs/*` from 7.6.8 to 7.6.11
- Update `@babel/helper-call-delegate` from 7.12.1 to 7.12.13

## Rust

- Update `anyhow` from 1.0.32 to 1.0.38
- Update `console_log` from 0.1.2 to 0.2.0
- Update `log` from 0.4.8 to 0.4.14
- Update `serde` from 1.0.116 to 1.0.123
- Update `serde_json` from 1.0.58 to 1.0.62
- Update `yew` from 0.17.3 to 0.17.4
- Update `wasm-bindgen` from 0.2.68 to 0.2.70
- Update `wasm-bindgen-futures` from 0.4.10 to 0.4.20
- Update `wasm-bindgen-test` from 0.2 to 0.3.19
- Update `wee_alloc` from 0.4.2 to 0.4.5