### PR TITLE
Only create board when the id of `GameState` changes

### DIFF
--- a/ui-rs/crates/mines_mogwai/src/components/cell.rs
+++ b/ui-rs/crates/mines_mogwai/src/components/cell.rs
@@ -1,4 +1,4 @@
-use crate::model::{CellInteract, CellInteractKind};
+use crate::model::{CellInteract, CellInteractKind, CellUpdate};
 use mogwai::prelude::*;
 
 pub struct BoardCell {
@@ -30,7 +30,7 @@ impl BoardCell {
 
 impl Component for BoardCell {
     type ModelMsg = BoardCellInteract;
-    type ViewMsg = BoardValue;
+    type ViewMsg = CellUpdate;
     type DomNode = HtmlElement;
 
     fn update(
@@ -51,12 +51,17 @@ impl Component for BoardCell {
             row: self.row,
             kind,
         };
+        let board_value = match kind {
+            CellInteractKind::RemoveFlag => BoardValue::Closed,
+            CellInteractKind::Flag => BoardValue::Flag,
+            CellInteractKind::Open => BoardValue::Pending,
+        };
         // Optimistically update the cell because certain actions don't depend
         // on the game state so the `BoardCell` "knows" the result
-        tx.send(match kind {
-            CellInteractKind::RemoveFlag => &BoardValue::Closed,
-            CellInteractKind::Flag => &BoardValue::Flag,
-            CellInteractKind::Open => &BoardValue::Pending,
+        tx.send(&CellUpdate::Single {
+            column: self.column,
+            row: self.row,
+            value: board_value.to_string(),
         });
         // Send the `CellInteract` out it (may) eventually result in receiving
         // a `ViewMessage`
@@ -69,7 +74,22 @@ impl Component for BoardCell {
         tx: &Transmitter<Self::ModelMsg>,
         rx: &Receiver<Self::ViewMsg>,
     ) -> ViewBuilder<HtmlElement> {
-        let rx_text = rx.branch_map(|update| update.to_string());
+        let col = self.column;
+        let row = self.row;
+        let rx_value: Receiver<BoardValue> = rx.branch_filter_map(move |update| match update {
+            CellUpdate::All { cells } => cells
+                .get(row)
+                .map(|r| r.get(col))
+                .flatten()
+                .map(|s| s.into()),
+            CellUpdate::Single {
+                row: y,
+                column: x,
+                value,
+            } if *x == col && *y == row => Some(value.into()),
+            _ => None,
+        });
+        let rx_text = rx_value.branch_map(|update| update.to_string());
         builder! {
             <td
                 on:click=tx.contra_map(|event: &Event| BoardCellInteract::from(event))

--- a/ui-rs/crates/mines_mogwai/src/components/cell.rs
+++ b/ui-rs/crates/mines_mogwai/src/components/cell.rs
@@ -9,22 +9,23 @@ pub struct BoardCell {
 }
 
 impl BoardCell {
-    pub fn new<T>(
-        coords: (usize, usize),
-        initial_value: T,
-        tx_cells: Transmitter<CellInteract>,
-    ) -> Self
-    where
-        T: AsRef<str>,
-    {
-        let (column, row) = coords;
-        let current_display: BoardValue = initial_value.into();
-        BoardCell {
-            column,
-            current_display,
-            row,
-            tx_cells,
-        }
+    pub fn gizmo(
+        column: usize,
+        row: usize,
+        initial_value: String,
+        tx: &Transmitter<CellInteract>,
+        rx: &Receiver<CellUpdate>,
+    ) -> Gizmo<Self> {
+        Gizmo::from_parts(
+            BoardCell {
+                column,
+                current_display: initial_value.into(),
+                row,
+                tx_cells: tx.clone(),
+            },
+            Transmitter::new(),
+            rx.branch(),
+        )
     }
 }
 

--- a/ui-rs/crates/mines_mogwai/src/components/game.rs
+++ b/ui-rs/crates/mines_mogwai/src/components/game.rs
@@ -10,14 +10,10 @@ fn board_row<'a>(
     rx: &Receiver<CellUpdate>,
 ) -> ViewBuilder<HtmlElement> {
     use crate::components::cell::BoardCell;
-    let children = initial_cells.into_iter().enumerate().map(|(col, value)| {
-        Gizmo::from_parts(
-            BoardCell::new((col, row), &value, tx.clone()),
-            Transmitter::new(),
-            rx.branch(),
-        )
-        .view_builder()
-    });
+    let children = initial_cells
+        .into_iter()
+        .enumerate()
+        .map(|(col, value)| BoardCell::gizmo(col, row, value, tx, rx).view_builder());
     let mut tr = builder! { <tr /> };
     for child in children {
         tr.with(child);

--- a/ui-rs/crates/mines_mogwai/src/components/game.rs
+++ b/ui-rs/crates/mines_mogwai/src/components/game.rs
@@ -1,39 +1,6 @@
 use crate::model::{CellInteract, CellUpdate};
 use mogwai::prelude::*;
 
-/// Create a `<td>` representing a single game cell. `coords` are expected to be `(column, row)` or
-/// `(x, y)` in the grid. Interactions are transmitted to `tx` and new text to display is received
-/// by `rx`.
-#[allow(unused_braces)]
-fn board_cell<'a>(
-    coords: (usize, usize, String),
-    tx: &Transmitter<CellInteract>,
-    rx: &Receiver<CellUpdate>,
-) -> ViewBuilder<HtmlElement> {
-    use crate::components::cell::{BoardCell, BoardValue};
-    let (col, row, initial_value) = coords;
-    let tx_in = Transmitter::new();
-    let rx_value: Receiver<BoardValue> = rx.branch_filter_map(move |update| match update {
-        CellUpdate::All { cells } => cells
-            .get(row)
-            .map(|r| r.get(col))
-            .flatten()
-            .map(|s| s.into()),
-        CellUpdate::Single {
-            row: y,
-            column: x,
-            value,
-        } if *x == col && *y == row => Some(value.into()),
-        _ => None,
-    });
-    let c = Gizmo::from_parts(
-        BoardCell::new((col, row), &initial_value, tx.clone()),
-        tx_in,
-        rx_value,
-    );
-    c.view_builder()
-}
-
 /// Create a `<tr>` representing a row of game cells. Interactions are transmitted to `tx` and new
 /// text to display is received by `rx`.
 fn board_row<'a>(
@@ -42,10 +9,15 @@ fn board_row<'a>(
     tx: &Transmitter<CellInteract>,
     rx: &Receiver<CellUpdate>,
 ) -> ViewBuilder<HtmlElement> {
-    let children = initial_cells
-        .into_iter()
-        .enumerate()
-        .map(|(col, value)| board_cell((col, row, value), tx, rx));
+    use crate::components::cell::BoardCell;
+    let children = initial_cells.into_iter().enumerate().map(|(col, value)| {
+        Gizmo::from_parts(
+            BoardCell::new((col, row), &value, tx.clone()),
+            Transmitter::new(),
+            rx.branch(),
+        )
+        .view_builder()
+    });
     let mut tr = builder! { <tr /> };
     for child in children {
         tr.with(child);

--- a/ui-rs/crates/mines_mogwai/src/components/game.rs
+++ b/ui-rs/crates/mines_mogwai/src/components/game.rs
@@ -57,12 +57,12 @@ fn board_row<'a>(
 pub fn board<'a>(
     cells: Vec<Vec<String>>,
     tx: &Transmitter<CellInteract>,
+    rx: &Receiver<CellUpdate>,
 ) -> ViewBuilder<HtmlElement> {
-    let rx = Receiver::new();
     let children = cells
         .into_iter()
         .enumerate()
-        .map(|(row, cells)| board_row(row, cells, tx, &rx));
+        .map(|(row, cells)| board_row(row, cells, tx, rx));
     let mut tbody: ViewBuilder<HtmlElement> = builder! { <tbody /> };
     for child in children {
         tbody.with(child);

--- a/ui-rs/crates/mines_mogwai/src/model/cell_update.rs
+++ b/ui-rs/crates/mines_mogwai/src/model/cell_update.rs
@@ -1,3 +1,4 @@
+#[derive(Clone)]
 pub enum CellUpdate {
     All {
         cells: Vec<Vec<String>>,


### PR DESCRIPTION
Hold the `GameState` in a fold function that replaces the `GameState` contents of an `Option` when the ids do not match. This change allows the `<table>` to only be created once and relies on the `BoardCell` to be smart about when it should update.