### PR TITLE
Change `BoardValue` to a concept at the API level

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,2 +1,3 @@
 #/bin/sh
 yarn pretty-quick --staged
+cargo fmt

--- a/ui-rs/crates/mines_mogwai/src/api.rs
+++ b/ui-rs/crates/mines_mogwai/src/api.rs
@@ -67,7 +67,7 @@ pub mod model {
     #[derive(Clone, Debug, Deserialize)]
     pub struct GameState {
         pub id: GameId,
-        pub board: Vec<Vec<String>>,
+        pub board: Vec<Vec<crate::model::BoardValue>>,
         pub status: GameStatus,
     }
 

--- a/ui-rs/crates/mines_mogwai/src/components/game.rs
+++ b/ui-rs/crates/mines_mogwai/src/components/game.rs
@@ -5,7 +5,7 @@ use mogwai::prelude::*;
 /// text to display is received by `rx`.
 fn board_row<'a>(
     row: usize,
-    initial_cells: Vec<String>,
+    initial_cells: Vec<crate::model::BoardValue>,
     tx: &Transmitter<CellInteract>,
     rx: &Receiver<CellUpdate>,
 ) -> ViewBuilder<HtmlElement> {
@@ -23,7 +23,7 @@ fn board_row<'a>(
 
 #[allow(unused_braces)]
 pub fn board<'a>(
-    cells: Vec<Vec<String>>,
+    cells: Vec<Vec<crate::model::BoardValue>>,
     tx: &Transmitter<CellInteract>,
     rx: &Receiver<CellUpdate>,
 ) -> ViewBuilder<HtmlElement> {

--- a/ui-rs/crates/mines_mogwai/src/model.rs
+++ b/ui-rs/crates/mines_mogwai/src/model.rs
@@ -1,5 +1,7 @@
+mod board_value;
 mod cell_interact;
 mod cell_update;
 
+pub use board_value::BoardValue;
 pub use cell_interact::{CellInteract, CellInteractKind};
 pub use cell_update::CellUpdate;

--- a/ui-rs/crates/mines_mogwai/src/model/board_value.rs
+++ b/ui-rs/crates/mines_mogwai/src/model/board_value.rs
@@ -1,0 +1,60 @@
+/// Defines the possible values of a cell on the board.
+#[derive(Clone, Copy, Debug)]
+pub enum BoardValue {
+    /// An unopened cell, waiting for interaction
+    Closed,
+    /// A cell which has been flagged as a possible mine
+    Flag,
+    /// A cell which has been opened and contains a mine
+    Mine,
+    /// An opened cell indicating how many of its neighbors are mines
+    Open(usize),
+    /// A cell whose interaction is pending
+    Pending,
+}
+
+impl std::fmt::Display for BoardValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BoardValue::Closed => f.write_str(" "),
+            BoardValue::Flag => f.write_str("F"),
+            BoardValue::Mine => f.write_str("M"),
+            BoardValue::Open(count) => f.write_fmt(format_args!("{}", count)),
+            BoardValue::Pending => f.write_str("*"),
+        }
+    }
+}
+
+impl<T> From<T> for BoardValue
+where
+    T: AsRef<str>,
+{
+    fn from(value: T) -> Self {
+        let current = value.as_ref();
+        if current == "" || current == " " {
+            BoardValue::Closed
+        } else if current == "M" {
+            BoardValue::Mine
+        } else if current == "F" {
+            BoardValue::Flag
+        } else if current == "*" {
+            BoardValue::Pending
+        } else {
+            use std::str::FromStr;
+            match usize::from_str(&current) {
+                Ok(v) => BoardValue::Open(v),
+                _ => BoardValue::Closed,
+            }
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for BoardValue {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Ok(BoardValue::from(s))
+    }
+}

--- a/ui-rs/crates/mines_mogwai/src/model/cell_update.rs
+++ b/ui-rs/crates/mines_mogwai/src/model/cell_update.rs
@@ -1,12 +1,12 @@
 #[derive(Clone)]
 pub enum CellUpdate {
     All {
-        cells: Vec<Vec<String>>,
+        cells: Vec<Vec<crate::model::BoardValue>>,
     },
     #[allow(unused)]
     Single {
         row: usize,
         column: usize,
-        value: String,
+        value: crate::model::BoardValue,
     },
 }

--- a/ui-rs/crates/mines_mogwai/src/routes/game.rs
+++ b/ui-rs/crates/mines_mogwai/src/routes/game.rs
@@ -134,7 +134,7 @@ mod game_board {
 
     /// Create a `Vec` of owned `String` values.
     macro_rules! vec_of_strings {
-        ($($x:expr),*) => (vec![$($x.to_string()),*]);
+        ($($x:expr),*) => (vec![$($x.into()),*]);
     }
 
     #[test]

--- a/ui-rs/crates/mines_mogwai/src/routes/game_list.rs
+++ b/ui-rs/crates/mines_mogwai/src/routes/game_list.rs
@@ -71,7 +71,7 @@ impl Component for GameList {
         in_sub.send_async(async {
             match crate::api::get_game_list().await {
                 Ok(ids) => GameListModel::ReplaceList {
-                    game_ids: Rc::new(ids.clone()),
+                    game_ids: Rc::new(ids),
                 },
                 Err(_) => GameListModel::ReplaceList {
                     game_ids: Rc::new(vec![]),

--- a/ui-rs/crates/mines_uirs/src/api.rs
+++ b/ui-rs/crates/mines_uirs/src/api.rs
@@ -6,7 +6,7 @@ use yew::callback::Callback;
 use yew::format::{Json, Nothing};
 use yew::services::fetch::{FetchService, FetchTask, Request, Response};
 
-const API_BASE_URL: &str = dotenv!("API_BASE_URL");
+const API_BASE_URL: &str = dotenv!("UI_BASE_API_URL");
 
 pub type GameBoard = Vec<Vec<String>>;
 pub type GameId = String;


### PR DESCRIPTION
The `BoardValue` enum makes it possible to pass the `Vec`s of cell values around with fewer allocations because `BoardValue` can be `Copy` and the `String` it represents can not be.